### PR TITLE
feat: Add dynamic sensitive field support for expects/exposes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-* N/A
+* [FEAT] Add dynamic `sensitive:` option support for `expects` and `exposes` fields - accepts procs or symbols that are evaluated at runtime against the action instance, allowing conditional sensitivity based on input values (e.g., `exposes :data, sensitive: -> { redact_mode }`)
 
 ## 0.1.0-alpha.4.2
 * [FEAT] Add extensible field metadata support for `expects`/`exposes`:

--- a/docs/reference/class.md
+++ b/docs/reference/class.md
@@ -20,6 +20,58 @@ Both `expects` and `exposes` support the same core options:
 | `type` | `expects :foo, type: String` | Custom type validation -- fail unless `name.is_a?(String)`
 | anything else | `expects :foo, inclusion: { in: [:apple, :peach] }` | Any other arguments will be processed [as ActiveModel validations](https://guides.rubyonrails.org/active_record_validations.html) (i.e. as if passed to `validates :foo, <...>` on an ActiveRecord model)
 
+### Dynamic `sensitive` fields
+
+The `sensitive` option can accept a proc or symbol in addition to a boolean, allowing you to conditionally filter fields based on runtime values:
+
+```ruby
+class MyAction
+  include Axn
+
+  expects :include_pii, type: :boolean
+  expects :ssn, sensitive: -> { !include_pii }
+
+  exposes :api_response, sensitive: :should_redact?
+
+  def call
+    expose api_response: fetch_data
+  end
+
+  private
+
+  def should_redact?
+    !include_pii || api_response[:contains_secrets]
+  end
+end
+
+# When include_pii is false, ssn is filtered
+MyAction.call(include_pii: false, ssn: "123-45-6789")
+#=> inputs: { ssn: [FILTERED], include_pii: false }
+
+# When include_pii is true, ssn is visible
+MyAction.call(include_pii: true, ssn: "123-45-6789")
+#=> inputs: { ssn: "123-45-6789", include_pii: true }
+```
+
+The callable receives no arguments and is evaluated via `instance_exec`, so it has access to:
+- All `expects` field values (via their reader methods)
+- Exposed values (for `exposes` fields)
+- Any instance methods defined on the action
+
+::: warning Timing: sensitive evaluated before defaults
+For `expects` fields, the `sensitive` callable is evaluated **before** defaults are applied. This means if your sensitivity logic depends on another field's value, that field should either be required or you should handle `nil` explicitly:
+
+```ruby
+# CAUTION: mode may be nil if caller doesn't provide it
+expects :mode, default: "public"
+expects :api_key, sensitive: -> { mode != "debug" }  # mode could be nil here!
+
+# SAFER: handle nil explicitly
+expects :api_key, sensitive: -> { mode.nil? || mode != "debug" }
+```
+
+This is because automatic logging of inputs happens before defaults are applied in the execution flow. For `exposes` fields, this is not a concern since output logging happens after the action completes.
+:::
 
 ### Validation details
 

--- a/lib/axn/core/context/facade_inspector.rb
+++ b/lib/axn/core/context/facade_inspector.rb
@@ -65,19 +65,25 @@ module Axn
       inspection_filter.filter_param(field, inspected_value)
     end
 
-    def inspection_filter = action.class.inspection_filter
+    def inspection_filter
+      @inspection_filter ||= if action.class._has_dynamic_sensitive_fields?
+                               action.class._build_instance_filter(action)
+                             else
+                               action.class.inspection_filter
+                             end
+    end
 
     def sensitive_subfields?(field)
-      action.subfield_configs.any? { |config| config.on == field && config.sensitive }
+      action.subfield_configs.any? do |config|
+        config.on == field && action.class._resolve_sensitive_value(config.sensitive, action)
+      end
     end
 
     def filter_subfields(field, value)
-      # Build a nested structure with subfield paths for filtering
       nested_data = { field => value }
 
-      # Create a filter with the subfield paths
       sensitive_subfield_paths = action.subfield_configs
-                                       .select { |config| config.on == field && config.sensitive }
+                                       .select { |config| config.on == field && action.class._resolve_sensitive_value(config.sensitive, action) }
                                        .map { |config| "#{field}.#{config.field}" }
 
       return value if sensitive_subfield_paths.empty?

--- a/lib/axn/core/contract.rb
+++ b/lib/axn/core/contract.rb
@@ -87,7 +87,42 @@ module Axn
         end
 
         def sensitive_fields
-          (internal_field_configs + external_field_configs + subfield_configs).select(&:sensitive).map(&:field)
+          _static_sensitive_fields
+        end
+
+        def _static_sensitive_fields
+          (internal_field_configs + external_field_configs + subfield_configs).select { |c| c.sensitive == true }.map(&:field)
+        end
+
+        def _has_dynamic_sensitive_fields?
+          @_has_dynamic_sensitive_fields ||= (internal_field_configs + external_field_configs + subfield_configs).any? do |config|
+            config.sensitive.is_a?(Proc) || config.sensitive.is_a?(Symbol)
+          end
+        end
+
+        def _resolve_sensitive_fields(action_instance)
+          return _static_sensitive_fields unless _has_dynamic_sensitive_fields?
+
+          (internal_field_configs + external_field_configs + subfield_configs).select do |config|
+            _resolve_sensitive_value(config.sensitive, action_instance)
+          end.map(&:field)
+        end
+
+        def _resolve_sensitive_value(sensitive, action_instance)
+          case sensitive
+          when true, false
+            sensitive
+          when Symbol
+            !!action_instance.send(sensitive)
+          when Proc
+            !!action_instance.instance_exec(&sensitive)
+          else
+            !!sensitive
+          end
+        end
+
+        def _build_instance_filter(action_instance)
+          ActiveSupport::ParameterFilter.new(_resolve_sensitive_fields(action_instance))
         end
 
         def _declared_fields(direction)
@@ -104,8 +139,14 @@ module Axn
 
         # Internal method for filtering context data by direction
         # Used by instance methods (inputs_for_logging, outputs_for_logging) and async exception reporting
-        def _context_slice(data:, direction: nil)
-          inspection_filter.filter(data.slice(*_declared_fields(direction)))
+        # When action_instance is provided, dynamic sensitive fields are resolved against that instance.
+        def _context_slice(data:, direction: nil, action_instance: nil)
+          filter = if action_instance && _has_dynamic_sensitive_fields?
+                     _build_instance_filter(action_instance)
+                   else
+                     inspection_filter
+                   end
+          filter.filter(data.slice(*_declared_fields(direction)))
         end
 
         private
@@ -266,12 +307,12 @@ module Axn
 
         # Filtered inbound fields only (no additional context) - used by automatic logging and execution_context
         def inputs_for_logging
-          self.class._context_slice(data: @__context.__combined_data, direction: :inbound)
+          self.class._context_slice(data: @__context.__combined_data, direction: :inbound, action_instance: self)
         end
 
         # Filtered outbound fields only (no additional context) - used by automatic logging and execution_context
         def outputs_for_logging
-          self.class._context_slice(data: @__context.__combined_data, direction: :outbound)
+          self.class._context_slice(data: @__context.__combined_data, direction: :outbound, action_instance: self)
         end
 
         def _build_context_facade(direction)

--- a/spec/axn/core/dynamic_sensitive_spec.rb
+++ b/spec/axn/core/dynamic_sensitive_spec.rb
@@ -1,0 +1,283 @@
+# frozen_string_literal: true
+
+RSpec.describe "Dynamic sensitive fields" do
+  describe "exposes with callable sensitive" do
+    context "with a proc" do
+      let(:action) do
+        build_axn do
+          expects :redact_mode, type: :boolean, default: false
+
+          exposes :public_data
+          exposes :secret_data, sensitive: -> { redact_mode }
+
+          def call
+            expose public_data: "visible"
+            expose secret_data: "hidden-value"
+          end
+        end
+      end
+
+      context "when redact_mode is true" do
+        subject { action.call(redact_mode: true) }
+
+        it "filters the sensitive field in inspect" do
+          expect(subject.inspect).to include("secret_data: [FILTERED]")
+          expect(subject.inspect).to include("public_data: \"visible\"")
+        end
+
+        it "filters the sensitive field in outputs_for_logging" do
+          instance = action.send(:new, redact_mode: true)
+          instance.call
+          outputs = instance.send(:outputs_for_logging)
+
+          expect(outputs[:secret_data]).to eq("[FILTERED]")
+          expect(outputs[:public_data]).to eq("visible")
+        end
+      end
+
+      context "when redact_mode is false" do
+        subject { action.call(redact_mode: false) }
+
+        it "does not filter the field in inspect" do
+          expect(subject.inspect).to include("secret_data: \"hidden-value\"")
+          expect(subject.inspect).to include("public_data: \"visible\"")
+        end
+
+        it "does not filter the field in outputs_for_logging" do
+          instance = action.send(:new, redact_mode: false)
+          instance.call
+          outputs = instance.send(:outputs_for_logging)
+
+          expect(outputs[:secret_data]).to eq("hidden-value")
+          expect(outputs[:public_data]).to eq("visible")
+        end
+      end
+    end
+
+    context "with a symbol referencing an instance method" do
+      let(:action) do
+        build_axn do
+          expects :user_role, type: String
+
+          exposes :admin_details, sensitive: :hide_admin_details?
+
+          def call
+            expose admin_details: "admin-secret-info"
+          end
+
+          private
+
+          def hide_admin_details?
+            user_role != "admin"
+          end
+        end
+      end
+
+      context "when user is admin" do
+        subject { action.call(user_role: "admin") }
+
+        it "does not filter the field" do
+          expect(subject.inspect).to include("admin_details: \"admin-secret-info\"")
+        end
+      end
+
+      context "when user is not admin" do
+        subject { action.call(user_role: "guest") }
+
+        it "filters the field" do
+          expect(subject.inspect).to include("admin_details: [FILTERED]")
+        end
+      end
+    end
+  end
+
+  describe "expects with callable sensitive" do
+    let(:action) do
+      build_axn do
+        expects :include_pii, type: :boolean, default: false
+        expects :ssn, sensitive: -> { !include_pii }
+
+        exposes :processed
+
+        def call
+          expose processed: "done"
+        end
+      end
+    end
+
+    context "when include_pii is false (default)" do
+      it "filters ssn in inputs_for_logging" do
+        instance = action.send(:new, ssn: "123-45-6789")
+        outputs = instance.send(:inputs_for_logging)
+
+        expect(outputs[:ssn]).to eq("[FILTERED]")
+      end
+
+      it "filters ssn in internal_context inspect" do
+        result = action.call(ssn: "123-45-6789")
+        expect(result.__action__.internal_context.inspect).to include("ssn: [FILTERED]")
+      end
+    end
+
+    context "when include_pii is true" do
+      it "does not filter ssn in inputs_for_logging" do
+        instance = action.send(:new, include_pii: true, ssn: "123-45-6789")
+        outputs = instance.send(:inputs_for_logging)
+
+        expect(outputs[:ssn]).to eq("123-45-6789")
+      end
+    end
+  end
+
+  describe "mixed static and dynamic sensitive fields" do
+    let(:action) do
+      build_axn do
+        expects :verbose_mode, type: :boolean, default: false
+
+        exposes :always_hidden, sensitive: true
+        exposes :conditionally_hidden, sensitive: -> { !verbose_mode }
+        exposes :never_hidden
+
+        def call
+          expose always_hidden: "secret1"
+          expose conditionally_hidden: "secret2"
+          expose never_hidden: "public"
+        end
+      end
+    end
+
+    context "when verbose_mode is false" do
+      subject { action.call(verbose_mode: false) }
+
+      it "filters both sensitive fields" do
+        expect(subject.inspect).to include("always_hidden: [FILTERED]")
+        expect(subject.inspect).to include("conditionally_hidden: [FILTERED]")
+        expect(subject.inspect).to include("never_hidden: \"public\"")
+      end
+    end
+
+    context "when verbose_mode is true" do
+      subject { action.call(verbose_mode: true) }
+
+      it "still filters static sensitive but not dynamic" do
+        expect(subject.inspect).to include("always_hidden: [FILTERED]")
+        expect(subject.inspect).to include("conditionally_hidden: \"secret2\"")
+        expect(subject.inspect).to include("never_hidden: \"public\"")
+      end
+    end
+  end
+
+  describe "subfields with callable sensitive" do
+    let(:action) do
+      build_axn do
+        expects :redact_password, type: :boolean, default: true
+        expects :user_data, type: Hash
+        expects :password, on: :user_data, sensitive: -> { redact_password }
+        expects :email, on: :user_data
+
+        def call; end
+      end
+    end
+
+    let(:user_data) { { email: "user@example.com", password: "secret123" } }
+
+    context "when redact_password is true" do
+      it "filters the password subfield in inputs_for_logging" do
+        instance = action.send(:new, user_data:, redact_password: true)
+        inputs = instance.send(:inputs_for_logging)
+
+        expect(inputs[:user_data][:password]).to eq("[FILTERED]")
+        expect(inputs[:user_data][:email]).to eq("user@example.com")
+      end
+    end
+
+    context "when redact_password is false" do
+      it "does not filter the password subfield" do
+        instance = action.send(:new, user_data:, redact_password: false)
+        inputs = instance.send(:inputs_for_logging)
+
+        expect(inputs[:user_data][:password]).to eq("secret123")
+        expect(inputs[:user_data][:email]).to eq("user@example.com")
+      end
+    end
+  end
+
+  describe "class-level methods" do
+    let(:action) do
+      build_axn do
+        expects :mode
+        exposes :data, sensitive: -> { mode == "secret" }
+      end
+    end
+
+    describe "._has_dynamic_sensitive_fields?" do
+      it "returns true when there are callable sensitive fields" do
+        expect(action._has_dynamic_sensitive_fields?).to be true
+      end
+
+      it "returns false when all sensitive fields are static" do
+        static_action = build_axn do
+          expects :input, sensitive: true
+          exposes :output, sensitive: false
+        end
+        expect(static_action._has_dynamic_sensitive_fields?).to be false
+      end
+    end
+
+    describe ".sensitive_fields (static)" do
+      it "only returns statically sensitive fields" do
+        mixed_action = build_axn do
+          expects :static_sensitive, sensitive: true
+          expects :dynamic_sensitive, sensitive: -> { true }
+          expects :not_sensitive
+        end
+
+        expect(mixed_action.sensitive_fields).to eq([:static_sensitive])
+      end
+    end
+
+    describe "._resolve_sensitive_fields" do
+      it "resolves callable sensitive values against the action instance" do
+        instance = action.send(:new, mode: "secret")
+        resolved = action._resolve_sensitive_fields(instance)
+        expect(resolved).to include(:data)
+      end
+
+      it "returns empty when callable evaluates to false" do
+        instance = action.send(:new, mode: "public")
+        resolved = action._resolve_sensitive_fields(instance)
+        expect(resolved).not_to include(:data)
+      end
+    end
+  end
+
+  describe "execution_context integration" do
+    let(:action) do
+      build_axn do
+        expects :hide_output, type: :boolean, default: false
+
+        exposes :output, sensitive: -> { hide_output }
+
+        def call
+          expose output: "sensitive-data"
+        end
+      end
+    end
+
+    it "uses dynamic filtering in execution_context" do
+      instance = action.send(:new, hide_output: true)
+      instance.call
+      ctx = instance.execution_context
+
+      expect(ctx[:outputs][:output]).to eq("[FILTERED]")
+    end
+
+    it "does not filter when dynamic condition is false" do
+      instance = action.send(:new, hide_output: false)
+      instance.call
+      ctx = instance.execution_context
+
+      expect(ctx[:outputs][:output]).to eq("sensitive-data")
+    end
+  end
+end


### PR DESCRIPTION
Linear: [PRO-1989](https://linear.app/teamshares/issue/PRO-1989/axn-support-dynamic-sensitive-true-tagging)

## Summary

Allow the `sensitive:` option on `expects` and `exposes` fields to accept procs or symbols that are evaluated at runtime against the action instance. This enables conditional sensitivity based on input values.

## Usage

```ruby
class MyAction
  include Axn

  expects :include_pii, type: :boolean
  expects :ssn, sensitive: -> { !include_pii }

  exposes :api_response, sensitive: :should_redact?

  def call
    expose api_response: fetch_data
  end

  private

  def should_redact?
    !include_pii || api_response[:contains_secrets]
  end
end

# When include_pii is false, ssn is filtered in logs/inspect
MyAction.call(include_pii: false, ssn: "123-45-6789")
#=> ssn: [FILTERED]

# When include_pii is true, values are shown
MyAction.call(include_pii: true, ssn: "123-45-6789")
#=> ssn: "123-45-6789"
```

## Important: Timing with defaults

For `expects` fields, the `sensitive` callable is evaluated **before** defaults are applied. This is because input logging happens early in the execution flow. If your sensitivity logic depends on another field that has a default, you should handle `nil` explicitly:

```ruby
# CAUTION: mode may be nil at sensitivity-check time if caller doesn't provide it
expects :mode, default: "public"
expects :api_key, sensitive: -> { mode != "debug" }  # mode could be nil here!

# SAFER: handle nil explicitly
expects :api_key, sensitive: -> { mode.nil? || mode != "debug" }
```

For `exposes` fields, this is not a concern since output logging happens after the action completes.

## Implementation

- `sensitive:` now accepts `true`, `false`, a Proc, or a Symbol
- Procs are evaluated via `instance_exec` against the action instance
- Symbols are called as instance methods on the action
- Static `sensitive: true` fields still use the cached class-level filter (optimization)
- Only actions with dynamic sensitive fields fall back to instance-level resolution
- Works for `expects`, `exposes`, and subfields (via `on:`)