### PR TITLE
fix: ExceptionContext no longer raises on unpersisted AR records (PRO-2383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* [BUGFIX] `ExceptionContext.build` no longer raises `URI::GID::MissingModelIdError` when an exposed or expected value is an unpersisted ActiveRecord record. The formatter now renders such values as `#<ClassName (unpersisted)>` and the optional retry command falls back to `inspect` instead of generating `Model.find(nil)`.
 * [FEAT] Add dynamic `sensitive:` option support for `expects` and `exposes` fields - accepts procs or symbols that are evaluated at runtime against the action instance, allowing conditional sensitivity based on input values (e.g., `exposes :data, sensitive: -> { redact_mode }`)
 
 ## 0.1.0-alpha.4.2

--- a/lib/axn/internal/exception_context.rb
+++ b/lib/axn/internal/exception_context.rb
@@ -82,7 +82,11 @@ module Axn
         # Format a single non-container value for error tracking.
         def format_single_value(value)
           if value.respond_to?(:to_global_id)
-            value.to_global_id.to_s
+            begin
+              value.to_global_id.to_s
+            rescue ::URI::GID::MissingModelIdError
+              "#<#{value.class.name} (unpersisted)>"
+            end
           elsif defined?(ActionController::Parameters) && value.is_a?(ActionController::Parameters)
             format_hash_values(value.to_unsafe_h)
           elsif value.is_a?(Axn::FormObject)
@@ -117,9 +121,11 @@ module Axn
           # Handle ActiveRecord model instances
           if value.respond_to?(:to_global_id) && value.respond_to?(:id) && !value.is_a?(Class)
             begin
-              model_class = value.class.name
               id = value.id
-              return "#{model_class}.find(#{id.inspect})"
+              if id
+                model_class = value.class.name
+                return "#{model_class}.find(#{id.inspect})"
+              end
             rescue StandardError
               # If accessing id fails, fall through to default behavior
             end

--- a/spec/axn/internal/exception_context_spec.rb
+++ b/spec/axn/internal/exception_context_spec.rb
@@ -162,11 +162,12 @@ RSpec.describe Axn::Internal::ExceptionContext do
           def self.name = "FakeRecord"
 
           def to_global_id
-            raise ::URI::GID::MissingModelIdError, "Unable to create a GlobalID without a model id"
+            raise URI::GID::MissingModelIdError, "Unable to create a GlobalID without a model id"
           end
 
           def id = nil
-          def respond_to?(method, include_private = false)
+
+          def respond_to?(method, include_private: false)
             %i[to_global_id id].include?(method) || super
           end
 
@@ -180,7 +181,8 @@ RSpec.describe Axn::Internal::ExceptionContext do
           define_method(:to_global_id) { fake_gid }
           def id = 42
           def self.name = "FakeRecord"
-          def respond_to?(method, include_private = false)
+
+          def respond_to?(method, include_private: false)
             %i[to_global_id id].include?(method) || super
           end
         end

--- a/spec/axn/internal/exception_context_spec.rb
+++ b/spec/axn/internal/exception_context_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "globalid"
+
 RSpec.describe Axn::Internal::ExceptionContext do
   describe ".build" do
     it "builds context with formatted inputs and outputs" do
@@ -151,6 +153,110 @@ RSpec.describe Axn::Internal::ExceptionContext do
         expect(result[:retry_command]).to eq("NoExpectationsAction.call()")
       ensure
         Axn.config._include_retry_command_in_exceptions = original_value
+      end
+    end
+
+    context "with unpersisted ActiveRecord-like objects" do
+      let(:unpersisted_class) do
+        Class.new do
+          def self.name = "FakeRecord"
+
+          def to_global_id
+            raise ::URI::GID::MissingModelIdError, "Unable to create a GlobalID without a model id"
+          end
+
+          def id = nil
+          def respond_to?(method, include_private = false)
+            %i[to_global_id id].include?(method) || super
+          end
+
+          def inspect = "#<FakeRecord (new record)>"
+        end
+      end
+
+      let(:persisted_class) do
+        fake_gid = double("GlobalID", to_s: "gid://app/FakeRecord/42")
+        Class.new do
+          define_method(:to_global_id) { fake_gid }
+          def id = 42
+          def self.name = "FakeRecord"
+          def respond_to?(method, include_private = false)
+            %i[to_global_id id].include?(method) || super
+          end
+        end
+      end
+
+      it "does not raise when an input is an unpersisted AR-like object" do
+        unpersisted = unpersisted_class.new
+
+        action_class = build_axn do
+          expects :record
+
+          def call; end
+        end
+
+        stub_const("TestAction", action_class)
+        instance = TestAction.new(record: unpersisted)
+
+        expect { described_class.build(action: instance) }.not_to raise_error
+      end
+
+      it "formats an unpersisted AR-like input as an informative string" do
+        unpersisted = unpersisted_class.new
+
+        action_class = build_axn do
+          expects :record
+
+          def call; end
+        end
+
+        stub_const("TestAction", action_class)
+        instance = TestAction.new(record: unpersisted)
+
+        result = described_class.build(action: instance)
+
+        expect(result[:inputs][:record]).to eq("#<FakeRecord (unpersisted)>")
+      end
+
+      it "still serializes a persisted AR-like input as a GID string" do
+        persisted = persisted_class.new
+
+        action_class = build_axn do
+          expects :record
+
+          def call; end
+        end
+
+        stub_const("TestAction", action_class)
+        instance = TestAction.new(record: persisted)
+
+        result = described_class.build(action: instance)
+
+        expect(result[:inputs][:record]).to eq("gid://app/FakeRecord/42")
+      end
+
+      it "generates retry_command using inspect for an unpersisted AR-like input" do
+        unpersisted = unpersisted_class.new
+
+        action_class = build_axn do
+          expects :record
+
+          def call; end
+        end
+
+        stub_const("TestAction", action_class)
+        instance = TestAction.new(record: unpersisted)
+
+        original = Axn.config._include_retry_command_in_exceptions
+        begin
+          Axn.config._include_retry_command_in_exceptions = true
+
+          result = described_class.build(action: instance)
+
+          expect(result[:retry_command]).to eq("TestAction.call(record: #{unpersisted.inspect})")
+        ensure
+          Axn.config._include_retry_command_in_exceptions = original
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

- `ExceptionContext.format_single_value` called `to_global_id.to_s` on any value responding to the method. Unpersisted ActiveRecord objects raise `URI::GID::MissingModelIdError` (no id), which masked the real error in dev environments with `raise_piping_errors_in_dev`.
- Fix rescues `::URI::GID::MissingModelIdError` and falls back to `"#<ClassName (unpersisted)>"`.
- `format_value_for_retry_command` now skips `Model.find(id)` when `id` is nil, falling through to `inspect` instead of emitting `Model.find(nil)`.

Reported via: https://github.com/teamshares/os-app/pull/4567#discussion_r3204059636

Linear: [PRO-2383](https://linear.app/teamshares/issue/PRO-2383/axn-exceptioncontext-raises-urigidmissingmodeliderror-on-unpersisted)
