### PR TITLE
Support plain namespace modules as Axn::Mountable hosts (PRO-2509)

### DIFF
--- a/docs/advanced/mountable.md
+++ b/docs/advanced/mountable.md
@@ -17,6 +17,39 @@ When you attach an action to a class, you get multiple ways to access it:
 1. **Direct method calls** on the class (e.g., `SomeClass.foo`), which depend on how you told it to mount
 3. **Namespace method calls** (e.g., `SomeClass::Axns.foo`) which always call the underlying axn directly (i.e. returning Axn::Result like a normal SomeAxn.call)
 
+## Host Types
+
+### Classes (`include Axn`)
+
+The typical host is a class that also `include Axn`. It gets the full mounting DSL, inheritable descriptors (subclasses receive mounts from their parent), and the `::Axns` namespace:
+
+```ruby
+class UserService
+  include Axn
+
+  mount_axn(:create_user) { |email:| expose :user_id, User.create!(email:).id }
+end
+```
+
+### Plain namespace modules (`include Axn::Mountable`)
+
+If your host is a namespace module — not itself an action — include `Axn::Mountable` directly instead:
+
+```ruby
+module MyGem
+  include Axn::Mountable
+
+  mount_axn :process, MyGem::ProcessAction
+end
+
+MyGem.process(...)     # => Axn::Result
+MyGem.process!(...)    # raises on failure
+MyGem.process_async(...)
+MyGem::Axns.process(...)
+```
+
+Mounting an existing named class on any host preserves the class's original `.name` — it will not be overwritten with the `::Axns::` namespace path.
+
 ## Attachment Strategies
 
 ### `axn` Strategy

--- a/docs/advanced/mountable.md
+++ b/docs/advanced/mountable.md
@@ -61,15 +61,14 @@ class UserService
   include Axn
 
   mount_axn(:create_user) do |email:, name:|
-    user = User.create!(email: email, name: name)
-    expose :user_id, user.id
+    User.create!(email: email, name: name)
   end
 end
 
 # Usage
 result = UserService.create_user(email: "user@example.com", name: "John")
 if result.ok?
-  puts "User created with ID: #{result.user_id}"
+  puts "User created: #{result.value.inspect}"
 else
   puts "Error: #{result.error}"
 end
@@ -460,8 +459,7 @@ class UserService
   include Axn
 
   mount_axn(:create) do |email:, name:|
-    user = User.create!(email: email, name: name)
-    expose :user_id, user.id
+    User.create!(email: email, name: name)
   end
 
   mount_axn_method(:find_by_email) do |email:|

--- a/docs/advanced/mountable.md
+++ b/docs/advanced/mountable.md
@@ -27,7 +27,7 @@ The typical host is a class that also `include Axn`. It gets the full mounting D
 class UserService
   include Axn
 
-  mount_axn(:create_user) { |email:| expose :user_id, User.create!(email:).id }
+  mount_axn(:create_user) { |email:| User.create!(email:) }
 end
 ```
 
@@ -162,8 +162,8 @@ class DataProcessor
   async :sidekiq
 
   mount_axn(:process_data, async: :sidekiq) do |data:|
-    # Processing logic
-    expose :processed_count, data.count
+    # Processing logic; return value is auto-exposed as result.value
+    data.count
   end
 end
 
@@ -217,13 +217,12 @@ class UserService
   # Inherits lifecycle (hooks, callbacks, messages, async) but not fields
   mount_axn :create_user do
     # Will run log_start before and track_success after
-    expose :user_id, 123
+    User.create!(email: "example@example.com")
   end
 
   # Completely independent - no inheritance
   step :validate_user do
     # Will NOT run log_start or track_success
-    expose :valid, true
   end
 end
 ```

--- a/lib/axn/mountable.rb
+++ b/lib/axn/mountable.rb
@@ -66,57 +66,57 @@ module Axn
     extend ActiveSupport::Concern
 
     def self.included(base)
-      if base.is_a?(Class)
-        base.class_eval do
-          class_attribute :_mounted_axn_descriptors, default: []
-
-          # Eagerly create action class constants for inherited descriptors
-          # (e.g. allow TeamsharesAPI::Company::Axns::Get.call to work *without* having to
-          # call TeamsharesAPI::Company.get! first)
-          def self.inherited(subclass)
-            super
-
-            # Only process if we have inherited descriptors from parent
-            return unless _mounted_axn_descriptors.any?
-
-            # Skip if subclass doesn't respond to _mounted_axn_descriptors
-            # This prevents recursion when creating action classes that inherit from target
-            return unless subclass.respond_to?(:_mounted_axn_descriptors)
-
-            # Skip if we're currently creating an action class (prevent infinite recursion)
-            # This is necessary because Axn::Factory.build creates classes that inherit from
-            # Axn (which includes Axn::Mountable), triggering inherited callbacks during
-            # action class creation.
-            superclass = subclass.superclass
-            creating_for = superclass&.instance_variable_get(:@_axn_creating_action_class_for)
-            return if creating_for
-
-            # Skip if this is an action class being created (they're in the Axns namespace)
-            # Action classes have names like "ParentClass::Axns::ActionName"
-            subclass_name = subclass.name
-            return if subclass_name&.include?("::Axns::")
-
-            # Eagerly create constants for all inherited descriptors
-            # mounted_axn_for will ensure namespace exists and create the constant
-            # If a child overrides, the new descriptor will replace the constant
-            _mounted_axn_descriptors.each do |descriptor|
-              # This will create the constant if it doesn't exist
-              descriptor.mounted_axn_for(target: subclass)
-              # Also define namespace methods on the child's namespace
-              # This ensures TeamsharesAPI::Company::Axns.get works even though
-              # the descriptor was originally mounted on TeamsharesAPI::Base
-              # We use define_namespace_methods instead of mount_to_namespace to
-              # avoid re-registering the constant (which is already created above)
-              descriptor.mount_strategy.define_namespace_methods(descriptor:, target: subclass)
-            end
-          end
-        end
-      else
+      unless base.is_a?(Class)
         # Module host: plain accessor — no class_attribute (Class-only) or inherited hook needed.
         base.instance_variable_set(:@_mounted_axn_descriptors, [])
         base.define_singleton_method(:_mounted_axn_descriptors) { @_mounted_axn_descriptors ||= [] }
         base.define_singleton_method(:_mounted_axn_descriptors=) { |val| @_mounted_axn_descriptors = val }
       end
+
+      base.class_eval do
+        class_attribute :_mounted_axn_descriptors, default: []
+
+        # Eagerly create action class constants for inherited descriptors
+        # (e.g. allow TeamsharesAPI::Company::Axns::Get.call to work *without* having to
+        # call TeamsharesAPI::Company.get! first)
+        def self.inherited(subclass)
+          super
+
+          # Only process if we have inherited descriptors from parent
+          return unless _mounted_axn_descriptors.any?
+
+          # Skip if subclass doesn't respond to _mounted_axn_descriptors
+          # This prevents recursion when creating action classes that inherit from target
+          return unless subclass.respond_to?(:_mounted_axn_descriptors)
+
+          # Skip if we're currently creating an action class (prevent infinite recursion)
+          # This is necessary because Axn::Factory.build creates classes that inherit from
+          # Axn (which includes Axn::Mountable), triggering inherited callbacks during
+          # action class creation.
+          superclass = subclass.superclass
+          creating_for = superclass&.instance_variable_get(:@_axn_creating_action_class_for)
+          return if creating_for
+
+          # Skip if this is an action class being created (they're in the Axns namespace)
+          # Action classes have names like "ParentClass::Axns::ActionName"
+          subclass_name = subclass.name
+          return if subclass_name&.include?("::Axns::")
+
+          # Eagerly create constants for all inherited descriptors
+          # mounted_axn_for will ensure namespace exists and create the constant
+          # If a child overrides, the new descriptor will replace the constant
+          _mounted_axn_descriptors.each do |descriptor|
+            # This will create the constant if it doesn't exist
+            descriptor.mounted_axn_for(target: subclass)
+            # Also define namespace methods on the child's namespace
+            # This ensures TeamsharesAPI::Company::Axns.get works even though
+            # the descriptor was originally mounted on TeamsharesAPI::Base
+            # We use define_namespace_methods instead of mount_to_namespace to
+            # avoid re-registering the constant (which is already created above)
+            descriptor.mount_strategy.define_namespace_methods(descriptor:, target: subclass)
+          end
+        end
+      end if base.is_a?(Class)
 
       MountingStrategies.all.each do |(_name, klass)|
         base.extend klass::DSL if klass.const_defined?(:DSL)

--- a/lib/axn/mountable.rb
+++ b/lib/axn/mountable.rb
@@ -73,50 +73,52 @@ module Axn
         base.define_singleton_method(:_mounted_axn_descriptors=) { |val| @_mounted_axn_descriptors = val }
       end
 
-      base.class_eval do
-        class_attribute :_mounted_axn_descriptors, default: []
+      if base.is_a?(Class)
+        base.class_eval do
+          class_attribute :_mounted_axn_descriptors, default: []
 
-        # Eagerly create action class constants for inherited descriptors
-        # (e.g. allow TeamsharesAPI::Company::Axns::Get.call to work *without* having to
-        # call TeamsharesAPI::Company.get! first)
-        def self.inherited(subclass)
-          super
+          # Eagerly create action class constants for inherited descriptors
+          # (e.g. allow TeamsharesAPI::Company::Axns::Get.call to work *without* having to
+          # call TeamsharesAPI::Company.get! first)
+          def self.inherited(subclass)
+            super
 
-          # Only process if we have inherited descriptors from parent
-          return unless _mounted_axn_descriptors.any?
+            # Only process if we have inherited descriptors from parent
+            return unless _mounted_axn_descriptors.any?
 
-          # Skip if subclass doesn't respond to _mounted_axn_descriptors
-          # This prevents recursion when creating action classes that inherit from target
-          return unless subclass.respond_to?(:_mounted_axn_descriptors)
+            # Skip if subclass doesn't respond to _mounted_axn_descriptors
+            # This prevents recursion when creating action classes that inherit from target
+            return unless subclass.respond_to?(:_mounted_axn_descriptors)
 
-          # Skip if we're currently creating an action class (prevent infinite recursion)
-          # This is necessary because Axn::Factory.build creates classes that inherit from
-          # Axn (which includes Axn::Mountable), triggering inherited callbacks during
-          # action class creation.
-          superclass = subclass.superclass
-          creating_for = superclass&.instance_variable_get(:@_axn_creating_action_class_for)
-          return if creating_for
+            # Skip if we're currently creating an action class (prevent infinite recursion)
+            # This is necessary because Axn::Factory.build creates classes that inherit from
+            # Axn (which includes Axn::Mountable), triggering inherited callbacks during
+            # action class creation.
+            superclass = subclass.superclass
+            creating_for = superclass&.instance_variable_get(:@_axn_creating_action_class_for)
+            return if creating_for
 
-          # Skip if this is an action class being created (they're in the Axns namespace)
-          # Action classes have names like "ParentClass::Axns::ActionName"
-          subclass_name = subclass.name
-          return if subclass_name&.include?("::Axns::")
+            # Skip if this is an action class being created (they're in the Axns namespace)
+            # Action classes have names like "ParentClass::Axns::ActionName"
+            subclass_name = subclass.name
+            return if subclass_name&.include?("::Axns::")
 
-          # Eagerly create constants for all inherited descriptors
-          # mounted_axn_for will ensure namespace exists and create the constant
-          # If a child overrides, the new descriptor will replace the constant
-          _mounted_axn_descriptors.each do |descriptor|
-            # This will create the constant if it doesn't exist
-            descriptor.mounted_axn_for(target: subclass)
-            # Also define namespace methods on the child's namespace
-            # This ensures TeamsharesAPI::Company::Axns.get works even though
-            # the descriptor was originally mounted on TeamsharesAPI::Base
-            # We use define_namespace_methods instead of mount_to_namespace to
-            # avoid re-registering the constant (which is already created above)
-            descriptor.mount_strategy.define_namespace_methods(descriptor:, target: subclass)
+            # Eagerly create constants for all inherited descriptors
+            # mounted_axn_for will ensure namespace exists and create the constant
+            # If a child overrides, the new descriptor will replace the constant
+            _mounted_axn_descriptors.each do |descriptor|
+              # This will create the constant if it doesn't exist
+              descriptor.mounted_axn_for(target: subclass)
+              # Also define namespace methods on the child's namespace
+              # This ensures TeamsharesAPI::Company::Axns.get works even though
+              # the descriptor was originally mounted on TeamsharesAPI::Base
+              # We use define_namespace_methods instead of mount_to_namespace to
+              # avoid re-registering the constant (which is already created above)
+              descriptor.mount_strategy.define_namespace_methods(descriptor:, target: subclass)
+            end
           end
         end
-      end if base.is_a?(Class)
+      end
 
       MountingStrategies.all.each do |(_name, klass)|
         base.extend klass::DSL if klass.const_defined?(:DSL)

--- a/lib/axn/mountable.rb
+++ b/lib/axn/mountable.rb
@@ -66,49 +66,56 @@ module Axn
     extend ActiveSupport::Concern
 
     def self.included(base)
-      base.class_eval do
-        class_attribute :_mounted_axn_descriptors, default: []
+      if base.is_a?(Class)
+        base.class_eval do
+          class_attribute :_mounted_axn_descriptors, default: []
 
-        # Eagerly create action class constants for inherited descriptors
-        # (e.g. allow TeamsharesAPI::Company::Axns::Get.call to work *without* having to
-        # call TeamsharesAPI::Company.get! first)
-        def self.inherited(subclass)
-          super
+          # Eagerly create action class constants for inherited descriptors
+          # (e.g. allow TeamsharesAPI::Company::Axns::Get.call to work *without* having to
+          # call TeamsharesAPI::Company.get! first)
+          def self.inherited(subclass)
+            super
 
-          # Only process if we have inherited descriptors from parent
-          return unless _mounted_axn_descriptors.any?
+            # Only process if we have inherited descriptors from parent
+            return unless _mounted_axn_descriptors.any?
 
-          # Skip if subclass doesn't respond to _mounted_axn_descriptors
-          # This prevents recursion when creating action classes that inherit from target
-          return unless subclass.respond_to?(:_mounted_axn_descriptors)
+            # Skip if subclass doesn't respond to _mounted_axn_descriptors
+            # This prevents recursion when creating action classes that inherit from target
+            return unless subclass.respond_to?(:_mounted_axn_descriptors)
 
-          # Skip if we're currently creating an action class (prevent infinite recursion)
-          # This is necessary because Axn::Factory.build creates classes that inherit from
-          # Axn (which includes Axn::Mountable), triggering inherited callbacks during
-          # action class creation.
-          superclass = subclass.superclass
-          creating_for = superclass&.instance_variable_get(:@_axn_creating_action_class_for)
-          return if creating_for
+            # Skip if we're currently creating an action class (prevent infinite recursion)
+            # This is necessary because Axn::Factory.build creates classes that inherit from
+            # Axn (which includes Axn::Mountable), triggering inherited callbacks during
+            # action class creation.
+            superclass = subclass.superclass
+            creating_for = superclass&.instance_variable_get(:@_axn_creating_action_class_for)
+            return if creating_for
 
-          # Skip if this is an action class being created (they're in the Axns namespace)
-          # Action classes have names like "ParentClass::Axns::ActionName"
-          subclass_name = subclass.name
-          return if subclass_name&.include?("::Axns::")
+            # Skip if this is an action class being created (they're in the Axns namespace)
+            # Action classes have names like "ParentClass::Axns::ActionName"
+            subclass_name = subclass.name
+            return if subclass_name&.include?("::Axns::")
 
-          # Eagerly create constants for all inherited descriptors
-          # mounted_axn_for will ensure namespace exists and create the constant
-          # If a child overrides, the new descriptor will replace the constant
-          _mounted_axn_descriptors.each do |descriptor|
-            # This will create the constant if it doesn't exist
-            descriptor.mounted_axn_for(target: subclass)
-            # Also define namespace methods on the child's namespace
-            # This ensures TeamsharesAPI::Company::Axns.get works even though
-            # the descriptor was originally mounted on TeamsharesAPI::Base
-            # We use define_namespace_methods instead of mount_to_namespace to
-            # avoid re-registering the constant (which is already created above)
-            descriptor.mount_strategy.define_namespace_methods(descriptor:, target: subclass)
+            # Eagerly create constants for all inherited descriptors
+            # mounted_axn_for will ensure namespace exists and create the constant
+            # If a child overrides, the new descriptor will replace the constant
+            _mounted_axn_descriptors.each do |descriptor|
+              # This will create the constant if it doesn't exist
+              descriptor.mounted_axn_for(target: subclass)
+              # Also define namespace methods on the child's namespace
+              # This ensures TeamsharesAPI::Company::Axns.get works even though
+              # the descriptor was originally mounted on TeamsharesAPI::Base
+              # We use define_namespace_methods instead of mount_to_namespace to
+              # avoid re-registering the constant (which is already created above)
+              descriptor.mount_strategy.define_namespace_methods(descriptor:, target: subclass)
+            end
           end
         end
+      else
+        # Module host: plain accessor — no class_attribute (Class-only) or inherited hook needed.
+        base.instance_variable_set(:@_mounted_axn_descriptors, [])
+        base.define_singleton_method(:_mounted_axn_descriptors) { @_mounted_axn_descriptors ||= [] }
+        base.define_singleton_method(:_mounted_axn_descriptors=) { |val| @_mounted_axn_descriptors = val }
       end
 
       MountingStrategies.all.each do |(_name, klass)|

--- a/lib/axn/mountable/helpers/class_builder.rb
+++ b/lib/axn/mountable/helpers/class_builder.rb
@@ -67,7 +67,9 @@ module Axn
         end
 
         def configure_class_name_and_constant(axn_klass, name, axn_namespace, target)
-          configure_class_name(axn_klass, name, axn_namespace) if name.present?
+          # Skip renaming when mounting an existing named class — only anonymous (block-built) classes
+          # should have their .name overwritten with the namespace-qualified name.
+          configure_class_name(axn_klass, name, axn_namespace) if name.present? && !named_existing_class?
           register_constant(axn_klass, name, axn_namespace, target) if should_register_constant?(axn_namespace)
         end
 
@@ -78,6 +80,10 @@ module Axn
 
         def should_register_constant?(axn_namespace)
           axn_namespace&.name&.end_with?("::Axns")
+        end
+
+        def named_existing_class?
+          @descriptor.existing_axn_klass&.name.present?
         end
 
         def create_superclass_for_inherit_mode(target, inherit_config)

--- a/spec/axn/mountable/axn_spec.rb
+++ b/spec/axn/mountable/axn_spec.rb
@@ -599,7 +599,10 @@ RSpec.describe Axn do
 
     describe "existing named class .name preservation" do
       before do
-        stub_const("MyNamedAction", build_axn { exposes :output; def call = expose(output: "ok") })
+        stub_const("MyNamedAction", build_axn do
+          exposes :output
+          def call = expose(output: "ok")
+        end)
         client.mount_axn :my_action, MyNamedAction
       end
 

--- a/spec/axn/mountable/axn_spec.rb
+++ b/spec/axn/mountable/axn_spec.rb
@@ -597,6 +597,29 @@ RSpec.describe Axn do
       end
     end
 
+    describe "existing named class .name preservation" do
+      before do
+        stub_const("MyNamedAction", build_axn { exposes :output; def call = expose(output: "ok") })
+        client.mount_axn :my_action, MyNamedAction
+      end
+
+      it "does not clobber the mounted class's .name" do
+        expect(MyNamedAction.name).to eq("MyNamedAction")
+      end
+
+      it "still registers the constant in the Axns namespace" do
+        expect(client::Axns.const_defined?(:MyAction)).to be(true)
+      end
+
+      it "the Axns constant is the same object as the mounted class" do
+        expect(client::Axns::MyAction).to be(MyNamedAction)
+      end
+
+      it "delegates correctly despite no rename" do
+        expect(client.my_action.output).to eq("ok")
+      end
+    end
+
     describe "__axn_mounted_to__" do
       include_examples "__axn_mounted_to__ behavior", :mount_axn
 
@@ -641,6 +664,71 @@ RSpec.describe Axn do
           inherited_axn = child_class.const_get(:Axns).const_get(:ParentAction)
           expect(inherited_axn.__axn_mounted_to__).to eq(child_class)
         end
+      end
+    end
+  end
+
+  describe "module host (include Axn::Mountable)" do
+    let(:action_class) do
+      stub_const("HostSpec::MyAction", build_axn do
+        exposes :output
+        def call = expose(output: "from action")
+      end)
+    end
+
+    let(:host) { Module.new { include Axn::Mountable } }
+
+    it "succeeds on a plain module" do
+      expect { Module.new { include Axn::Mountable } }.not_to raise_error
+    end
+
+    it "initialises _mounted_axn_descriptors to []" do
+      expect(host._mounted_axn_descriptors).to eq([])
+    end
+
+    context "with an existing named action class" do
+      before { host.mount_axn :my_action, action_class }
+
+      it "defines .my_action on the module" do
+        expect(host).to respond_to(:my_action)
+      end
+
+      it "defines .my_action! on the module" do
+        expect(host).to respond_to(:my_action!)
+      end
+
+      it "defines .my_action_async on the module" do
+        expect(host).to respond_to(:my_action_async)
+      end
+
+      it "delegates .my_action to the class's .call" do
+        result = host.my_action
+        expect(result).to be_ok
+        expect(result.output).to eq("from action")
+      end
+
+      it "delegates .my_action! to the class's .call!" do
+        expect(host.my_action!.output).to eq("from action")
+      end
+
+      it "preserves the mounted class's original .name" do
+        expect(action_class.name).to eq("HostSpec::MyAction")
+      end
+
+      it "registers an Axns namespace on the host" do
+        expect(host.const_defined?(:Axns)).to be(true)
+      end
+
+      it "registers the class under Axns with the correct constant name" do
+        expect(host::Axns.const_defined?(:MyAction)).to be(true)
+      end
+
+      it "the Axns constant is the same object as the mounted class" do
+        expect(host::Axns::MyAction).to be(action_class)
+      end
+
+      it "Axns.my_action also delegates correctly" do
+        expect(host::Axns.my_action.output).to eq("from action")
       end
     end
   end


### PR DESCRIPTION
## Summary

- `Axn::Mountable` previously required the host to `include Axn` because `Mountable.included` called `class_attribute`, an ActiveSupport extension available only on `Class`. Plain namespace modules hit `NoMethodError: undefined method 'class_attribute'`.
- Branches `Mountable.included` on class vs. module: class hosts use the existing `class_attribute` + `inherited` hook path; module hosts get simple singleton-method accessors for `_mounted_axn_descriptors`. The `MountingStrategies` DSL extension runs for both, so `mount_axn` / `mount_axn_method` / `step` are available on module hosts.
- Fixes `.name` clobber: when `mount_axn` receives an existing named class (passthrough path), `ClassBuilder` previously overwrote its `.name` with the `::Axns::` namespace path. Now skips renaming for named existing classes — the `Axns` constant and namespace methods are still registered correctly.
- Adds 16 specs covering name preservation on class hosts and the full module-host scenario.
- Documents both host types and the name-preservation guarantee in `docs/advanced/mountable.md`.

## Motivation

`axn-ruby_llm` ([PR #5](https://github.com/teamshares/axn-ruby_llm/pull/5)) wants to adopt `mount_axn` for its `.ask` shortcut. The host (`Axn::RubyLLM`) is a plain namespace module — not itself an Axn action, and it shouldn't be. This PR is the upstream fix that unblocks that migration.

Tracked in [PRO-2509](https://linear.app/teamshares/issue/PRO-2509).
