### PR TITLE
Add boolean predicate readers

### DIFF
--- a/docs/reference/class.md
+++ b/docs/reference/class.md
@@ -82,6 +82,7 @@ While we _support_ complex interface validations, in practice you usually just w
 In addition to the [standard ActiveModel validations](https://guides.rubyonrails.org/active_record_validations.html), we also support four additional custom validators:
 * `type: Foo` - fails unless the provided value `.is_a?(Foo)`
   * Edge case: use `type: :boolean` to handle a boolean field (since ruby doesn't have a Boolean class to pass in directly)
+    * Boolean `expects` fields also define a predicate reader, so `expects :enabled, type: :boolean` provides both `enabled` and `enabled?` on the action instance. The same applies to subfield readers unless `readers: false` is set. Boolean `exposes` fields provide predicate readers on the result, so `exposes :enabled, type: :boolean` provides `result.enabled?`.
   * Edge case: use `type: :uuid` to handle a confirming given string is a UUID (with or without `-` chars)
   * Edge case: use `type: :params` to accept either a Hash or ActionController::Parameters (Rails-compatible)
 * `validate: [callable]` - Support custom validations (fails if any string is returned OR if it raises an exception)

--- a/lib/axn/core/contract.rb
+++ b/lib/axn/core/contract.rb
@@ -49,7 +49,8 @@ module Axn
                                                **validations)
           end
 
-          _parse_field_configs(*fields, allow_blank:, allow_nil:, optional:, default:, preprocess:, sensitive:, metadata:, **validations).tap do |configs|
+          _parse_field_configs(*fields, allow_blank:, allow_nil:, optional:, default:, preprocess:, sensitive:, metadata:,
+                                        predicate_readers: true, **validations).tap do |configs|
             duplicated = internal_field_configs.map(&:field) & configs.map(&:field)
             raise Axn::DuplicateFieldError, "Duplicate field(s) declared: #{duplicated.join(', ')}" if duplicated.any?
 
@@ -207,6 +208,7 @@ module Axn
           preprocess: nil,
           sensitive: false,
           metadata: {},
+          predicate_readers: false,
           **validations
         )
           # Handle optional: true by setting allow_blank: true
@@ -214,6 +216,7 @@ module Axn
 
           _parse_field_validations(*fields, allow_nil:, allow_blank:, **validations).map do |field, parsed_validations|
             _define_field_reader(field)
+            _define_boolean_predicate_reader(field) if predicate_readers && _boolean_field?(parsed_validations)
             FieldConfig.new(field:, validations: parsed_validations, default:, preprocess:, sensitive:, metadata:)
           end
         end
@@ -222,6 +225,20 @@ module Axn
           # Allow local access to explicitly-expected fields -- even externally-expected needs to be available locally
           # (e.g. to allow success message callable to reference exposed fields)
           define_method(field) { internal_context.public_send(field) }
+        end
+
+        def _define_boolean_predicate_reader(field)
+          field_name = field.to_s
+          return if field_name.end_with?("?") || field_name.include?(".")
+
+          predicate_name = "#{field_name}?"
+          return if method_defined?(predicate_name)
+
+          alias_method predicate_name, field
+        end
+
+        def _boolean_field?(validations)
+          Array(validations.dig(:type, :klass)) == [:boolean]
         end
 
         # This method applies any top-level options to each of the individual validations given.

--- a/lib/axn/core/contract_for_subfields.rb
+++ b/lib/axn/core/contract_for_subfields.rb
@@ -67,7 +67,10 @@ module Axn
           allow_blank ||= optional
 
           _parse_field_validations(*fields, allow_nil:, allow_blank:, **validations).map do |field, parsed_validations|
-            _define_subfield_reader(field, on:, validations: parsed_validations) if readers
+            if readers
+              _define_subfield_reader(field, on:, validations: parsed_validations)
+              _define_boolean_predicate_reader(field) if _boolean_field?(parsed_validations)
+            end
             SubfieldConfig.new(field:, validations: parsed_validations, on:, sensitive:, preprocess:, default:, metadata:)
           end
         end

--- a/lib/axn/result.rb
+++ b/lib/axn/result.rb
@@ -6,6 +6,11 @@ require "axn/core/context/facade_inspector"
 module Axn
   # Outbound / External ContextFacade
   class Result < ContextFacade
+    def initialize(...)
+      super
+      _define_boolean_predicate_readers
+    end
+
     # For ease of mocking return results in tests
     class << self
       def ok(msg = nil, **exposures)
@@ -100,6 +105,29 @@ module Axn
     private
 
     def _context_data_source = @context.exposed_data
+
+    def _define_boolean_predicate_readers
+      action.external_field_configs.each do |config|
+        next unless declared_fields.include?(config.field)
+        next unless _boolean_field?(config.validations)
+
+        _define_boolean_predicate_reader(config.field)
+      end
+    end
+
+    def _define_boolean_predicate_reader(field)
+      field_name = field.to_s
+      return if field_name.end_with?("?") || field_name.include?(".")
+
+      predicate_name = "#{field_name}?"
+      return if singleton_class.method_defined?(predicate_name)
+
+      singleton_class.alias_method predicate_name, field
+    end
+
+    def _boolean_field?(validations)
+      Array(validations.dig(:type, :klass)) == [:boolean]
+    end
 
     def _user_provided_success_message
       @context.__early_completion_message.presence

--- a/spec/axn/core/field_metadata_spec.rb
+++ b/spec/axn/core/field_metadata_spec.rb
@@ -220,4 +220,102 @@ RSpec.describe "Field metadata" do
       end.not_to raise_error
     end
   end
+
+  describe "boolean predicate readers" do
+    it "defines predicate readers for boolean expectations" do
+      action = build_axn do
+        expects :enabled, type: :boolean
+        exposes :predicate_value, type: :boolean
+
+        def call
+          expose predicate_value: enabled?
+        end
+      end
+
+      expect(action.call(enabled: true).predicate_value).to be(true)
+      expect(action.call(enabled: false).predicate_value).to be(false)
+    end
+
+    it "does not define predicate readers for non-boolean expectations" do
+      action = build_axn do
+        expects :name, type: String
+      end
+
+      expect(action.method_defined?(:name?)).to be(false)
+    end
+
+    it "defines predicate readers for boolean subfields when readers are enabled" do
+      action = build_axn do
+        expects :settings, type: Hash
+        expects :enabled, on: :settings, type: :boolean
+        exposes :predicate_value, type: :boolean
+
+        def call
+          expose predicate_value: enabled?
+        end
+      end
+
+      expect(action.call(settings: { enabled: true }).predicate_value).to be(true)
+      expect(action.call(settings: { enabled: false }).predicate_value).to be(false)
+    end
+
+    it "does not define predicate readers for boolean subfields when readers are disabled" do
+      action = build_axn do
+        expects :settings, type: Hash
+        expects :enabled, on: :settings, type: :boolean, readers: false
+      end
+
+      expect(action.method_defined?(:enabled?)).to be(false)
+    end
+
+    it "does not overwrite explicitly defined predicate methods" do
+      action = build_axn do
+        expects :enabled, type: :boolean
+        exposes :predicate_value, type: Symbol
+
+        def call
+          expose predicate_value: enabled?
+        end
+
+        def enabled?
+          :explicit_predicate
+        end
+      end
+
+      expect(action.call(enabled: true).predicate_value).to eq(:explicit_predicate)
+    end
+
+    it "defines predicate readers on results for boolean exposures" do
+      action = build_axn do
+        exposes :enabled, type: :boolean
+
+        def call
+          expose enabled: true
+        end
+      end
+      false_action = build_axn do
+        exposes :enabled, type: :boolean
+
+        def call
+          expose enabled: false
+        end
+      end
+
+      expect(action.call.enabled?).to be(true)
+      expect(false_action.call.enabled?).to be(false)
+      expect(action.method_defined?(:enabled?)).to be(false)
+    end
+
+    it "does not define result predicate readers for non-boolean exposures" do
+      action = build_axn do
+        exposes :name, type: String
+
+        def call
+          expose name: "Alice"
+        end
+      end
+
+      expect(action.call.respond_to?(:name?)).to be(false)
+    end
+  end
 end

--- a/spec/axn/core/hooks_and_callbacks_spec.rb
+++ b/spec/axn/core/hooks_and_callbacks_spec.rb
@@ -322,10 +322,6 @@ RSpec.describe Axn do
                 fail!("Custom failure message")
               end
             end
-
-            def should_skip?
-              should_skip
-            end
           end
         end
 


### PR DESCRIPTION
## Summary
- Add `foo?` predicate readers for boolean `expects` fields, including readable subfields.
- Add `result.foo?` predicate readers for boolean `exposes` fields without adding exposed-only predicates to the action instance.
- Document the predicate reader behavior and cover expectation, subfield, result exposure, and collision cases.