### PR TITLE
Remove direct action-instance readers for exposes (PRO-2522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+* [BREAKING] `exposes` no longer defines a direct reader method on the action instance. Exposed fields must be accessed via `result.field` (e.g., `result.greeting`). `expects` readers are unaffected. User-defined methods with the same name as an exposed field are preserved (DefaultCall still calls them). Use `result.field` in `success`/`error` message callables and `sensitive:` procs to access output values.
+* [FEAT] Add boolean predicate readers for `expects` and `exposes`: `expects :enabled, type: :boolean` defines `enabled?` on the action instance; `exposes :enabled, type: :boolean` defines `result.enabled?`.
 * [BUGFIX] `ExceptionContext.build` no longer raises `URI::GID::MissingModelIdError` when an exposed or expected value is an unpersisted ActiveRecord record. The formatter now renders such values as `#<ClassName (unpersisted)>` and the optional retry command falls back to `inspect` instead of generating `Model.find(nil)`.
 * [FEAT] Add dynamic `sensitive:` option support for `expects` and `exposes` fields - accepts procs or symbols that are evaluated at runtime against the action instance, allowing conditional sensitivity based on input values (e.g., `exposes :data, sensitive: -> { redact_mode }`)
 

--- a/docs/reference/class.md
+++ b/docs/reference/class.md
@@ -40,7 +40,7 @@ class MyAction
   private
 
   def should_redact?
-    !include_pii || api_response[:contains_secrets]
+    !include_pii || result.api_response[:contains_secrets]
   end
 end
 
@@ -54,8 +54,8 @@ MyAction.call(include_pii: true, ssn: "123-45-6789")
 ```
 
 The callable receives no arguments and is evaluated via `instance_exec`, so it has access to:
-- All `expects` field values (via their reader methods)
-- Exposed values (for `exposes` fields)
+- All `expects` field values (via their reader methods, e.g., `include_pii`)
+- Exposed values via `result.field` (e.g., `result.api_response`) — bare field names are **not** available for `exposes`-only fields
 - Any instance methods defined on the action
 
 ::: warning Timing: sensitive evaluated before defaults

--- a/lib/axn/core/contract.rb
+++ b/lib/axn/core/contract.rb
@@ -215,12 +215,12 @@ module Axn
           allow_blank ||= optional
 
           _parse_field_validations(*fields, allow_nil:, allow_blank:, **validations).map do |field, parsed_validations|
-            config = FieldConfig.new(field:, validations: parsed_validations, default:, preprocess:, sensitive:, metadata:)
-            if define_readers
-              _define_field_reader(field)
-              _define_boolean_predicate_reader(field) if Axn::Internal::FieldConfig.boolean?(config)
+            FieldConfig.new(field:, validations: parsed_validations, default:, preprocess:, sensitive:, metadata:).tap do |config|
+              if define_readers
+                _define_field_reader(field)
+                _define_boolean_predicate_reader(field) if Axn::Internal::FieldConfig.boolean?(config)
+              end
             end
-            config
           end
         end
 

--- a/lib/axn/core/contract.rb
+++ b/lib/axn/core/contract.rb
@@ -50,7 +50,7 @@ module Axn
           end
 
           _parse_field_configs(*fields, allow_blank:, allow_nil:, optional:, default:, preprocess:, sensitive:, metadata:,
-                                        predicate_readers: true, **validations).tap do |configs|
+                                        define_readers: true, **validations).tap do |configs|
             duplicated = internal_field_configs.map(&:field) & configs.map(&:field)
             raise Axn::DuplicateFieldError, "Duplicate field(s) declared: #{duplicated.join(', ')}" if duplicated.any?
 
@@ -208,22 +208,25 @@ module Axn
           preprocess: nil,
           sensitive: false,
           metadata: {},
-          predicate_readers: false,
+          define_readers: false,
           **validations
         )
           # Handle optional: true by setting allow_blank: true
           allow_blank ||= optional
 
           _parse_field_validations(*fields, allow_nil:, allow_blank:, **validations).map do |field, parsed_validations|
-            _define_field_reader(field)
-            _define_boolean_predicate_reader(field) if predicate_readers && _boolean_field?(parsed_validations)
-            FieldConfig.new(field:, validations: parsed_validations, default:, preprocess:, sensitive:, metadata:)
+            config = FieldConfig.new(field:, validations: parsed_validations, default:, preprocess:, sensitive:, metadata:)
+            if define_readers
+              _define_field_reader(field)
+              _define_boolean_predicate_reader(field) if Axn::Internal::FieldConfig.boolean?(config)
+            end
+            config
           end
         end
 
         def _define_field_reader(field)
-          # Allow local access to explicitly-expected fields -- even externally-expected needs to be available locally
-          # (e.g. to allow success message callable to reference exposed fields)
+          # Allow local access to explicitly-expected fields on the action instance.
+          # NOTE: exposes fields are intentionally excluded — access those via result.field instead.
           define_method(field) { internal_context.public_send(field) }
         end
 
@@ -235,10 +238,6 @@ module Axn
           return if method_defined?(predicate_name)
 
           alias_method predicate_name, field
-        end
-
-        def _boolean_field?(validations)
-          Array(validations.dig(:type, :klass)) == [:boolean]
         end
 
         # This method applies any top-level options to each of the individual validations given.

--- a/lib/axn/core/contract_for_subfields.rb
+++ b/lib/axn/core/contract_for_subfields.rb
@@ -67,12 +67,12 @@ module Axn
           allow_blank ||= optional
 
           _parse_field_validations(*fields, allow_nil:, allow_blank:, **validations).map do |field, parsed_validations|
-            config = SubfieldConfig.new(field:, validations: parsed_validations, on:, sensitive:, preprocess:, default:, metadata:)
-            if readers
-              _define_subfield_reader(field, on:, validations: parsed_validations)
-              _define_boolean_predicate_reader(field) if Axn::Internal::FieldConfig.boolean?(config)
+            SubfieldConfig.new(field:, validations: parsed_validations, on:, sensitive:, preprocess:, default:, metadata:).tap do |config|
+              if readers
+                _define_subfield_reader(field, on:, validations: parsed_validations)
+                _define_boolean_predicate_reader(field) if Axn::Internal::FieldConfig.boolean?(config)
+              end
             end
-            config
           end
         end
 

--- a/lib/axn/core/contract_for_subfields.rb
+++ b/lib/axn/core/contract_for_subfields.rb
@@ -67,11 +67,12 @@ module Axn
           allow_blank ||= optional
 
           _parse_field_validations(*fields, allow_nil:, allow_blank:, **validations).map do |field, parsed_validations|
+            config = SubfieldConfig.new(field:, validations: parsed_validations, on:, sensitive:, preprocess:, default:, metadata:)
             if readers
               _define_subfield_reader(field, on:, validations: parsed_validations)
-              _define_boolean_predicate_reader(field) if _boolean_field?(parsed_validations)
+              _define_boolean_predicate_reader(field) if Axn::Internal::FieldConfig.boolean?(config)
             end
-            SubfieldConfig.new(field:, validations: parsed_validations, on:, sensitive:, preprocess:, default:, metadata:)
+            config
           end
         end
 

--- a/lib/axn/internal/field_config.rb
+++ b/lib/axn/internal/field_config.rb
@@ -20,6 +20,14 @@ module Axn
         # Check if any validator has allow_blank: true
         validations.values.any? { |v| v.is_a?(Hash) && v[:allow_blank] == true }
       end
+
+      # Determines if a field is declared as boolean type.
+      #
+      # @param config [Object] A field configuration object with a `validations` method
+      # @return [Boolean] true if the field is typed :boolean
+      def boolean?(config)
+        Array(config.validations.dig(:type, :klass)) == [:boolean]
+      end
     end
   end
 end

--- a/lib/axn/result.rb
+++ b/lib/axn/result.rb
@@ -109,7 +109,7 @@ module Axn
     def _define_boolean_predicate_readers
       action.external_field_configs.each do |config|
         next unless declared_fields.include?(config.field)
-        next unless _boolean_field?(config.validations)
+        next unless Axn::Internal::FieldConfig.boolean?(config)
 
         _define_boolean_predicate_reader(config.field)
       end
@@ -123,10 +123,6 @@ module Axn
       return if singleton_class.method_defined?(predicate_name)
 
       singleton_class.alias_method predicate_name, field
-    end
-
-    def _boolean_field?(validations)
-      Array(validations.dig(:type, :klass)) == [:boolean]
     end
 
     def _user_provided_success_message

--- a/spec/axn/core/field_metadata_spec.rb
+++ b/spec/axn/core/field_metadata_spec.rb
@@ -221,6 +221,51 @@ RSpec.describe "Field metadata" do
     end
   end
 
+  describe "expose action-instance readers" do
+    it "does not define an action-instance reader for exposes-only fields" do
+      action = build_axn do
+        exposes :result_only_field
+      end
+
+      expect(action.method_defined?(:result_only_field)).to be(false)
+    end
+
+    it "result.foo still returns the exposed value" do
+      action = build_axn do
+        exposes :greeting
+
+        def call
+          expose greeting: "hello"
+        end
+      end
+
+      expect(action.call.greeting).to eq("hello")
+    end
+
+    it "expects :foo still defines foo on the action instance" do
+      action = build_axn do
+        expects :name, type: String
+
+        def call; end
+      end
+
+      expect(action.method_defined?(:name)).to be(true)
+    end
+
+    it "an explicit def foo alongside exposes :foo is preserved and DefaultCall exposes it" do
+      action = build_axn do
+        exposes :computed_value, type: Integer
+
+        def computed_value
+          42
+        end
+      end
+
+      # DefaultCall calls the user-defined method and exposes the result
+      expect(action.call.computed_value).to eq(42)
+    end
+  end
+
   describe "boolean predicate readers" do
     it "defines predicate readers for boolean expectations" do
       action = build_axn do

--- a/spec/axn/core/messages_spec.rb
+++ b/spec/axn/core/messages_spec.rb
@@ -104,8 +104,8 @@ RSpec.describe Axn do
         end
 
         it { expect(result).to be_ok }
-        it "cannot access exposed vars directly (returns nil/empty)" do
-          is_expected.to eq("Great news: 123 from ")
+        it "raises NoMethodError (no direct reader), which is swallowed and falls back to default success" do
+          is_expected.to eq("Action completed successfully")
         end
       end
 

--- a/spec/axn/core/validations/outbound_validation_spec.rb
+++ b/spec/axn/core/validations/outbound_validation_spec.rb
@@ -145,23 +145,27 @@ RSpec.describe Axn do
       end
     end
 
-    context "is accessible on internal context" do
-      let(:action) do
-        build_axn do
+    context "exposed-only fields are not directly accessible on the action instance" do
+      it "raises NoMethodError when accessed bare inside call (use result.field instead)" do
+        action = build_axn do
           exposes :foo, default: "bar"
 
           def call
-            puts "Foo is: #{foo}"
+            foo # no direct reader — intentionally raises
           end
         end
+
+        result = action.call
+        expect(result).not_to be_ok
+        expect(result.exception).to be_a(NameError)
       end
 
-      subject { action.call }
+      it "result.foo still returns the default when no explicit expose call is made" do
+        action = build_axn do
+          exposes :foo, default: "bar"
+        end
 
-      it "is accessible" do
-        # TODO: if we apply defaults earlier, this would say bar
-        expect { subject }.to output("Foo is: \n").to_stdout
-        expect(subject).to be_ok
+        expect(action.call.foo).to eq("bar")
       end
     end
 


### PR DESCRIPTION
## Summary

Follow-up to #90. `exposes :foo` was silently defining a reader on the action instance that read from `internal_context` (input data) — so for an exposed-only field it always returned `nil`. This was misleading: exposed outputs should only be read via `result.field`.

- **[BREAKING]** `exposes :foo` no longer defines a reader on the action instance. Access exposed fields via `result.foo` instead.
- `expects` readers, boolean predicate readers (`foo?`), and `result.foo?` are unaffected.
- Explicit user-defined methods (`def foo`) alongside `exposes :foo` are preserved — DefaultCall still calls them.
- Extracts `Axn::Internal::FieldConfig.boolean?` helper to DRY the duplicated `_boolean_field?` private methods from #90.

Consumer audits of `os-app` and `buyout-app` found no reliance on the removed reader.

Closes [PRO-2522](https://linear.app/teamshares/issue/PRO-2522/axn-remove-direct-readers-for-exposures-apply-to-result-instead).
