### PR TITLE
PRO-2593 Auto-copy exposes-declared fields on fail! and exception paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* [FEAT] `exposes`-declared fields that are also `expects`-declared are now auto-copied from the input into the result on **all** outcome paths — success, `done!`, `fail!`, and unhandled exception. Previously, the auto-copy only ran on success/`done!` paths, leaving `result.field` as `nil` after `fail!` or an exception even when the field was provided as input. This is particularly useful for re-exposing mutated ActiveRecord objects (e.g. inspecting `user.errors` after a failed save). Explicit `expose` calls before a failure continue to work and take precedence.
 * [BREAKING] `exposes` no longer defines a direct reader method on the action instance. Exposed fields must be accessed via `result.field` (e.g., `result.greeting`). `expects` readers are unaffected. User-defined methods with the same name as an exposed field are preserved (DefaultCall still calls them). Use `result.field` in `success`/`error` message callables and `sensitive:` procs to access output values.
 * [FEAT] Add boolean predicate readers for `expects` and `exposes`: `expects :enabled, type: :boolean` defines `enabled?` on the action instance; `exposes :enabled, type: :boolean` defines `result.enabled?`.
 * [BUGFIX] `ExceptionContext.build` no longer raises `URI::GID::MissingModelIdError` when an exposed or expected value is an unpersisted ActiveRecord record. The formatter now renders such values as `#<ClassName (unpersisted)>` and the optional retry command falls back to `inspect` instead of generating `Model.find(nil)`.

--- a/docs/reference/axn-result.md
+++ b/docs/reference/axn-result.md
@@ -12,7 +12,7 @@ Every `call` invocation on an Axn will return an `Axn::Result` instance, which p
 | `outcome` | The execution outcome as a string inquirer (`success?`, `failure?`, `exception?`)
 | `elapsed_time` | Execution time in milliseconds (Float)
 | `finalized?` | `true` if the result has completed execution (either successfully or with an exception), `false` if still in progress
-| any `expose`d values | guaranteed to be set if `ok?` (since they have outgoing presence validations by default; any missing would have failed the action)
+| any `expose`d values | guaranteed to be set if `ok?`; fields that are also `expects`-declared are auto-copied and available on `fail!` and exception paths too (see [Re-exposing an expected field](/usage/writing#re-exposing-an-expected-field-auto-copy))
 
 NOTE: `success` and `error` (and so implicitly `message`) can be configured per-action via [the `success` and `error` declarations](/reference/class#success-and-error).
 

--- a/docs/reference/class.md
+++ b/docs/reference/class.md
@@ -128,7 +128,7 @@ If neither `optional`, `allow_blank` nor `allow_nil` is specified, a default pre
 
 ### Details specific to `.exposes`
 
-Remember that you'll need [a corresponding `expose` call](/reference/instance#expose) for every variable you declare via `exposes`.
+For fields you declare via `exposes`, you'll need [a corresponding `expose` call](/reference/instance#expose) — unless the field is also declared via `expects`, in which case axn auto-copies it from the input into the result on all outcome paths (success, `fail!`, and exception). See [Re-exposing an expected field](/usage/writing#re-exposing-an-expected-field-auto-copy).
 
 
 ### Details specific to `.expects`

--- a/docs/usage/writing.md
+++ b/docs/usage/writing.md
@@ -47,7 +47,7 @@ To abort execution with a specific error message, call `fail!`. You can also pro
 
 To complete execution early with a success result, call `done!` with an optional success message and exposures as keyword arguments.
 
-If you declare that your action `exposes` anything, you need to actually `expose` it.
+If you declare that your action `exposes` anything, you need to actually `expose` it — unless you're re-exposing a field you also `expects`, in which case axn auto-copies it for you (see below).
 
 ```ruby
 class Foo
@@ -66,6 +66,29 @@ end
 ```
 
 See [the reference doc](/reference/instance) for a few more handy helper methods (e.g. `#log`).
+
+### Re-exposing an expected field (auto-copy)
+
+When a field is declared with both `expects` and `exposes`, axn automatically copies it from the input into the result — no manual `expose` call needed. This works on **all outcome paths**: success, `done!`, `fail!`, and unhandled exceptions.
+
+This is particularly useful when an action mutates an ActiveRecord object in-place (e.g. `user.valid?` populates `user.errors`) and the caller needs to inspect the object after a failure:
+
+```ruby
+class UpdateUser
+  include Axn
+
+  expects :user, model: true
+  exposes :user               # auto-copied — no expose call needed
+
+  def call
+    user.assign_attributes(params)
+    fail! unless user.save    # user.errors is available on result.user even on failure
+  end
+end
+
+result = UpdateUser.call(user:, params:)
+result.user.errors.full_messages  # populated on both ok? and !ok?
+```
 
 ### Convenient failure with context
 

--- a/lib/axn/executor.rb
+++ b/lib/axn/executor.rb
@@ -187,6 +187,12 @@ module Axn
     rescue Internal::EarlyCompletion
       raise
     rescue StandardError => e
+      begin
+        apply_defaults!(:outbound)
+      rescue StandardError => defaults_error
+        Internal::PipingError.swallow("applying outbound defaults on failure", exception: defaults_error, action: @action)
+      end
+
       @context.__record_exception(e)
 
       @action_class._dispatch_callbacks(:error, action: @action, exception: e)

--- a/spec/axn/core/return_shape_spec.rb
+++ b/spec/axn/core/return_shape_spec.rb
@@ -94,5 +94,117 @@ RSpec.describe Axn do
         expect(result.preferences.object_id).to eq(preferences.object_id)
       end
     end
+
+    describe "re-exposing an expected kwarg without a manual expose call" do
+      let(:action) do
+        build_axn do
+          expects :preferences, type: Hash
+          exposes :preferences, type: Hash
+
+          def call
+            preferences[:foo] = "mutated"
+            # no expose call — auto-copied from provided_data at outbound contract step
+          end
+        end
+      end
+
+      it "exposes the mutated object without requiring an explicit expose call" do
+        preferences = { foo: "initial" }
+        result = action.call(preferences:)
+        expect(result).to be_ok
+        expect(result.preferences).to eq({ foo: "mutated" })
+        expect(result.preferences.object_id).to eq(preferences.object_id)
+      end
+    end
+  end
+
+  describe "exposures on non-success paths" do
+    # exposes-declared fields that weren't explicitly exposed should still be
+    # auto-copied from provided_data on fail! and exception paths — consistent
+    # with success. nil is worse than a possibly-partial object; callers check
+    # result.ok? before using the data, and withholding it helps no one.
+
+    let(:item) { { value: "original" } }
+
+    shared_examples "exposes expected kwargs" do |outcome_label|
+      it "auto-copies the expected kwarg to the result (#{outcome_label})" do
+        expect(result.item).to eq(item)
+        expect(result.item.object_id).to eq(item.object_id)
+      end
+
+      it "preserves in-place mutations made before the failure (#{outcome_label})" do
+        expect(result.item[:value]).to eq("mutated")
+      end
+    end
+
+    context "when fail! is called" do
+      let(:action) do
+        build_axn do
+          expects :item, type: Hash
+          exposes :item, type: Hash
+
+          def call
+            item[:value] = "mutated"
+            fail!("something went wrong")
+          end
+        end
+      end
+
+      let(:result) { action.call(item:) }
+
+      include_examples "exposes expected kwargs", "fail!"
+
+      it "is not ok" do
+        expect(result).not_to be_ok
+      end
+    end
+
+    context "when an unhandled exception is raised" do
+      let(:action) do
+        build_axn do
+          expects :item, type: Hash
+          exposes :item, type: Hash
+
+          def call
+            item[:value] = "mutated"
+            raise "something exploded"
+          end
+        end
+      end
+
+      let(:result) { action.call(item:) }
+
+      include_examples "exposes expected kwargs", "exception"
+
+      it "is not ok" do
+        expect(result).not_to be_ok
+      end
+    end
+
+    context "when an explicitly exposed field was set before fail!" do
+      let(:action) do
+        build_axn do
+          expects :item, type: Hash
+          exposes :item, type: Hash
+          exposes :extra, optional: true
+
+          def call
+            expose(extra: "set before failure")
+            item[:value] = "mutated"
+            fail!("something went wrong")
+          end
+        end
+      end
+
+      let(:result) { action.call(item:) }
+
+      it "keeps the explicitly exposed value" do
+        expect(result.extra).to eq("set before failure")
+      end
+
+      it "also auto-copies the expected kwarg" do
+        expect(result.item[:value]).to eq("mutated")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

When an action calls `fail!` or raises an unhandled exception, `apply_defaults!(:outbound)` never ran. Fields declared with `exposes :field` that weren't explicitly exposed before the failure were `nil` on the result — even when the same field was also declared with `expects :field`.

```ruby
expects :user
exposes :user

def call
  user.valid?           # adds errors to user in-place
  fail! unless user.errors.empty?
  # ...
end

result = MyAction.call(user: user)
result.user  # => nil  ❌  (was nil before this fix on fail! paths)
```

### Root cause

`done!` raises `Axn::Internal::EarlyCompletion`, which is caught *inside* `with_contract` — so `apply_defaults!(:outbound)` still ran.

`fail!` raises `Axn::Failure < StandardError`, which bypasses `with_contract` entirely and was caught by the outer `with_exception_handling` layer. `apply_defaults!(:outbound)` never ran. Unhandled exceptions followed the same path.

## Fix

Call `apply_defaults!(:outbound)` inside `with_exception_handling`'s rescue clause, before recording the exception. Any errors it raises are swallowed via `PipingError.swallow` so the original failure is never masked. Outbound *validation* (`validate_contract!(:outbound)`) is intentionally skipped on failure paths — enforcing type/presence constraints when the action already failed adds noise.

## Why nil is worse than a possibly-partial object

- `provided_data` holds the same object references the caller already has in their own variables — withholding them from `result` doesn't protect anything
- `fail!` and exceptions both can fire mid-mutation; there's no meaningful difference between the two on this axis
- `nil` where callers expect an object causes `NoMethodError` if they forget to guard — a second failure on top of the first
- The real protection is `result.ok?` — callers who need clean data check that first

## Tests

Three new test contexts in `return_shape_spec.rb`:
- `fail!` path: auto-copies expected kwarg, preserves mutations
- exception path: same
- explicitly exposed field before `fail!`: both the explicit value and the auto-copy are preserved

## Related

- Linear: [PRO-2593](https://linear.app/teamshares/issue/PRO-2593)
- Follow-up in os-app ([PRO-2591](https://linear.app/teamshares/issue/PRO-2591)): the `before { expose user: }` workaround in `UpdateTaxInformation` becomes redundant once this ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)