### PR TITLE
[Internal] PRO-2663 Exclude dummy app Gemfile from Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,12 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>teamshares/renovate-config:lib.json5"],
+  // The dummy app's Gemfile.lock is gitignored, and it pulls in axn via a local
+  // `path:` dependency, so Renovate's lockfile artifact update (`bundle lock`)
+  // fails (see https://github.com/teamshares/axn/pull/86). It only exists to
+  // exercise axn against a real Rails app, so exclude it from Renovate entirely.
+  // First two entries are Renovate's defaults (preserved since setting ignorePaths overrides them).
+  ignorePaths: ["**/node_modules/**", "**/bower_components/**", "spec_rails/dummy_app/Gemfile"],
   ignoreDeps: [
   ],
   "packageRules": [


### PR DESCRIPTION
## What

Add `spec_rails/dummy_app/Gemfile` to Renovate's `ignorePaths` so Renovate stops processing it entirely.

## Why

Renovate keeps opening dependency-bump PRs against the dummy app's Gemfile and failing the `renovate/artifacts` check (e.g. #86, the `puma 7→8` bump). The failure is structural, not transient:

- `spec_rails/dummy_app/Gemfile.lock` is gitignored (we don't publish a lockfile as a library).
- The dummy app pulls in axn via a local `gem "axn", path: "../../"` dependency.

So when Renovate runs `bundle lock` to regenerate the lockfile artifact during a dep bump, it can't succeed — every such PR goes red on `renovate/artifacts`.

The dummy app only exists to exercise axn against a real Rails app; we don't need Renovate managing its dependencies. Excluding the path via `ignorePaths` stops both the unwanted PRs and the artifact failures at the source.

Note: setting `ignorePaths` overrides Renovate's built-in defaults, so this PR re-lists `**/node_modules/**` and `**/bower_components/**` alongside the new entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)