### PR TITLE
PRO-2664 Namespace internal instance variables on the action instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* [INTERNAL] Namespaced the framework's internal instance variables on the action instance (`@result` → `@__result`, `@internal_context` → `@__internal_context`) and the class-level `@inspection_filter` → `@__inspection_filter`, so a user assigning their own `@result`/`@internal_context` inside an action can no longer clobber exposed-value extraction or message rendering. No public API change — the `result` / `internal_context` methods are unchanged.
+
 ## 0.1.0-alpha.4.3
 * [FEAT] Plain namespace **modules** can now host mounted actions: `include Axn::Mountable` on a module (not just a class) exposes `mount_axn` / `mount_axn_method` / `step`. Class hosts keep the existing `class_attribute` + `inherited` behavior; module hosts use singleton accessors and skip the `inherited` hook (modules have no subclasses). Also fixes a `.name` clobber so passing an already-named class to `mount_axn` preserves its original name instead of rewriting it to the `Axns` namespace path.
 * [BUGFIX] Fixed an off-by-one in `async.attempt` reported from the Sidekiq death handler: Sidekiq increments `retry_count` before invoking death handlers, so an exhausted `retry: 3` job (4 executions) reported attempt `5` instead of `4`. The bug was metadata-only — control flow (`retries_exhausted?`, `first_attempt?`, `should_trigger_on_exception?`) was unaffected. Also documents why framework-native integrations (e.g. Honeybadger's Sidekiq plugin) can produce duplicate async error reports, with a tag-and-filter suppression recipe.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-* [INTERNAL] Namespaced the framework's internal instance variables on the action instance (`@result` → `@__result`, `@internal_context` → `@__internal_context`) and the class-level `@inspection_filter` → `@__inspection_filter`, so a user assigning their own `@result`/`@internal_context` inside an action can no longer clobber exposed-value extraction or message rendering. No public API change — the `result` / `internal_context` methods are unchanged.
+* [INTERNAL] Namespaced the framework's internal instance variables on the action instance (`@result` → `@__result`, `@internal_context` → `@__internal_context`) and the class-level `@inspection_filter` → `@__inspection_filter`, so a user assigning their own `@result`/`@internal_context` inside an action can no longer clobber exposed-value extraction or message rendering. The unrelated `@result` memo on the internal `DiscardedJobAction` proxy was renamed `@discarded_job_result` to avoid conflating it with the facade. No public API change — the `result` / `internal_context` methods are unchanged.
 
 ## 0.1.0-alpha.4.3
 * [FEAT] Plain namespace **modules** can now host mounted actions: `include Axn::Mountable` on a module (not just a class) exposes `mount_axn` / `mount_axn_method` / `step`. Class hosts keep the existing `class_attribute` + `inherited` behavior; module hosts use singleton accessors and skip the `inherited` hook (modules have no subclasses). Also fixes a `.name` clobber so passing an already-named class to `mount_axn` preserves its original name instead of rewriting it to the `Axns` namespace path.

--- a/lib/axn/async/exception_reporting.rb
+++ b/lib/axn/async/exception_reporting.rb
@@ -48,7 +48,7 @@ module Axn
         end
 
         def result
-          @result ||= DiscardedJobResult.new(@exception)
+          @discarded_job_result ||= DiscardedJobResult.new(@exception)
         end
 
         def class

--- a/lib/axn/core/contract.rb
+++ b/lib/axn/core/contract.rb
@@ -112,7 +112,7 @@ module Axn
         end
 
         def inspection_filter
-          @inspection_filter ||= ActiveSupport::ParameterFilter.new(sensitive_fields)
+          @__inspection_filter ||= ActiveSupport::ParameterFilter.new(sensitive_fields)
         end
 
         def sensitive_fields
@@ -368,8 +368,8 @@ module Axn
       RESERVED_EXECUTION_CONTEXT_KEYS = %i[inputs outputs].freeze
 
       module InstanceMethods
-        def internal_context = @internal_context ||= _build_context_facade(:inbound)
-        def result = @result ||= _build_context_facade(:outbound)
+        def internal_context = @__internal_context ||= _build_context_facade(:inbound)
+        def result = @__result ||= _build_context_facade(:outbound)
 
         delegate :default_error, :default_success, to: :internal_context
 

--- a/spec/axn/core/internal_ivar_isolation_spec.rb
+++ b/spec/axn/core/internal_ivar_isolation_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Regression: the framework memoizes its context facades into namespaced instance variables
+# (@__result / @__internal_context) so that a user who innocently assigns their own @result or
+# @internal_context inside an action does not clobber exposed-value extraction or message rendering.
+# See PRO-2664.
+RSpec.describe "internal instance variable isolation" do
+  let(:action) do
+    build_axn do
+      expects :name, type: String
+      exposes :greeting, type: String
+      exposes :user_result, allow_blank: true
+
+      success "static success"
+
+      def call
+        # A user innocently reusing these common names for their own state must not
+        # corrupt the framework's facades.
+        @result = "user's own result"
+        @internal_context = "user's own context"
+
+        expose greeting: "hi #{name}", user_result: @result
+      end
+    end
+  end
+
+  subject(:result) { action.call(name: "bob") }
+
+  it "does not let a user @result clobber exposed-value extraction" do
+    expect(result).to be_ok
+    expect(result.greeting).to eq("hi bob")
+  end
+
+  it "renders messages correctly despite a user-defined @internal_context" do
+    expect(result.success).to eq("static success")
+  end
+
+  it "preserves the user's own @result value" do
+    expect(result.user_result).to eq("user's own result")
+  end
+end


### PR DESCRIPTION
Fixes [PRO-2664](https://linear.app/teamshares/issue/PRO-2664/axn-underscore-internal-instance-variables).

## Problem

The framework memoized its context facades into instance variables on the **action instance** — the `self` a user's `call`, helpers, and `success`/`error` blocks run as — using plain, un-namespaced names:

- `@result` — backs the public `result` method (outbound facade)
- `@internal_context` — backs `internal_context` (inbound facade)

If a user innocently assigned their own `@result`/`@internal_context`, the `||=` short-circuited and the public method returned the user's object. The executor then extracted exposed values and rendered messages off the wrong object — failing silently-ish (no error, just wrong/`nil` exposed values reaching the caller). This got more likely in alpha.4.3, since removing the `exposes` instance readers (PRO-2522) funnels users toward `result` and some reach for `@result` directly.

## Fix

Rename to the existing `@__` convention used elsewhere in the instance (`@__context`, `@__additional_execution_context`):

- `@result` → `@__result`
- `@internal_context` → `@__internal_context`
- `@inspection_filter` → `@__inspection_filter` (class-level; included while here)

**Pure internal rename — zero public API change.** The `result` / `internal_context` / `inspection_filter` methods are untouched.

## Verification

- New regression spec (`spec/axn/core/internal_ivar_isolation_spec.rb`): a user-defined `@result`/`@internal_context` no longer corrupts exposed-value extraction or message rendering, and the user's own value is preserved.
- Full suite: **1757 examples, 0 failures**. RuboCop clean.
- Audited every ivar across all modules mixed into the action; the remaining framework ivars on the instance are already `@__`/`@_`-namespaced. Everything else lives on separate helper objects.
- Wrapper-gem grep: `axn-mcp` and `axn-ruby_llm` are both clean — no direct ivar access (axn-mcp uses the public `result.` method; axn-ruby_llm has none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)