### PR TITLE
PRO-2665 Add missing require "date" to contract.rb

### DIFF
--- a/lib/axn/core/contract.rb
+++ b/lib/axn/core/contract.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "date"
+
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/module/delegation"
 

--- a/spec/axn/core/date_require_spec.rb
+++ b/spec/axn/core/date_require_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Contract::SHAPE_INCOMPATIBLE_TYPES references Date and DateTime at load time.
+# Without an explicit `require "date"`, this raises NameError in any environment
+# where the stdlib date has not been loaded before axn.
+RSpec.describe "axn/core/contract" do
+  it "explicitly requires 'date' so Date and DateTime are defined at load time" do
+    contract_source = File.read(File.expand_path("../../../lib/axn/core/contract.rb", __dir__))
+    expect(contract_source).to include('require "date"')
+  end
+end


### PR DESCRIPTION
## Summary

- `SHAPE_INCOMPATIBLE_TYPES` in `lib/axn/core/contract.rb` references `Date` and `DateTime` at load time, but `require "date"` was never declared in the gem
- Any consumer whose environment didn't happen to load the stdlib `date` before `axn` would get a `NameError` at require time
- Adds the explicit `require "date"` alongside the existing `active_support` requires at the top of `contract.rb`

