### PR TITLE
PRO-2743 Add on_enqueue_all fan-out summary hook

### DIFF
--- a/docs/reference/async.md
+++ b/docs/reference/async.md
@@ -380,6 +380,57 @@ end
 SyncWithMode.enqueue_all(sync_mode: :full)
 ```
 
+### Run summary with `on_enqueue_all`
+
+`on_enqueue_all` registers a once-per-run callback that fires **after** the batch fan-out
+completes — useful for posting a summary, emitting a metric, or logging a heartbeat without
+hand-rolling a parent wrapper action. It runs inside the orchestrator (off the clock thread),
+in the context of your action class, so class-level `log`/`info`/`warn` are available.
+
+```ruby
+class StockCertificate::EoyTaxReminder
+  include Axn
+  async :sidekiq
+
+  expects :tax_profile, model: TaxProfile
+  enqueues_each :tax_profile, from: -> { TaxProfile.needs_address_validation }
+
+  on_enqueue_all do |sources:, count:|
+    active, inactive = sources[:tax_profile].partition { _1.user.active? }
+    SlackSender.call(channel: :eng_ops, text: "#{active.size} active, #{inactive.size} deactivated (#{count} enqueued)")
+  end
+
+  def call
+    # per-tax-profile work
+  end
+end
+```
+
+The block may declare any subset of these keyword arguments (or none):
+
+- **`count:`** — the exact number of jobs enqueued (post-filter). Always available, including
+  for cross-product runs.
+- **`sources:`** — a hash of `{ field => resolved_source }` for each iterated field, e.g.
+  `{ tax_profile: <relation> }` or, for a cross-product, `{ user: <rel>, company: <rel> }`.
+  Sources are the resolved-but-un-materialized relations (run your own `.count` / `.group` /
+  `.partition`), and reflect any kwarg overrides passed to `enqueue_all`.
+
+```ruby
+# Count-only heartbeat:
+on_enqueue_all { |count:| info "Found #{count} events" }
+```
+
+Multiple `on_enqueue_all` declarations are allowed and fire in declaration order.
+
+**Error handling:** a raise inside the block is swallowed (logged; re-raised in development
+only when `Axn.config.raise_piping_errors_in_dev` is set) and cannot change the enqueue
+outcome — the fan-out has already completed. This matches `on_success` semantics; rescue
+inside your block if you need stronger guarantees.
+
+**When it fires:** on any run that goes through the fan-out (the async path and the foreground
+path used when an iterable kwarg can't be serialized). It does **not** fire for an action with
+no `expects`, which enqueues a single job directly without fanning out.
+
 ### Memory Efficiency
 
 For optimal memory usage, model-based configs (using `find_each`) are automatically processed first in nested iterations. This ensures ActiveRecord-style batch processing happens before loading potentially large enumerables into memory.

--- a/docs/reference/async.md
+++ b/docs/reference/async.md
@@ -387,6 +387,10 @@ completes — useful for posting a summary, emitting a metric, or logging a hear
 hand-rolling a parent wrapper action. It runs inside the orchestrator (off the clock thread),
 in the context of your action class, so class-level `log`/`info`/`warn` are available.
 
+Like the other `on_*` callbacks, it accepts either a block or a Symbol method name (a Symbol
+resolves to a **class** method, since no action instance exists during enqueueing), and
+supports `if:`/`unless:` conditions.
+
 ```ruby
 class StockCertificate::EoyTaxReminder
   include Axn
@@ -406,7 +410,7 @@ class StockCertificate::EoyTaxReminder
 end
 ```
 
-The block may declare any subset of these keyword arguments (or none):
+The handler may declare any subset of these keyword arguments (or none):
 
 - **`count:`** — the exact number of jobs enqueued (post-filter). Always available, including
   for cross-product runs.
@@ -416,16 +420,23 @@ The block may declare any subset of these keyword arguments (or none):
   `.partition`), and reflect any kwarg overrides passed to `enqueue_all`.
 
 ```ruby
-# Count-only heartbeat:
-on_enqueue_all { |count:| info "Found #{count} events" }
+# Count-only heartbeat via a class method:
+on_enqueue_all :log_summary
+def self.log_summary(count:) = info "Found #{count} events"
+
+# Conditional summary:
+on_enqueue_all(if: :summary_enabled?) { |count:| info "Found #{count} events" }
 ```
 
-Multiple `on_enqueue_all` declarations are allowed and fire in declaration order.
+Multiple `on_enqueue_all` declarations are allowed; like the rest of the `on_*` family they
+fire **most-recent-first** (last-defined wins). `if:`/`unless:` conditions are evaluated the
+same way as the other callbacks' matchers (against the action, with no exception), so they can
+condition on class-level state but **cannot** observe `sources`/`count`.
 
-**Error handling:** a raise inside the block is swallowed (logged; re-raised in development
+**Error handling:** a raise inside the handler is swallowed (logged; re-raised in development
 only when `Axn.config.raise_piping_errors_in_dev` is set) and cannot change the enqueue
 outcome — the fan-out has already completed. This matches `on_success` semantics; rescue
-inside your block if you need stronger guarantees.
+inside your handler if you need stronger guarantees.
 
 **When it fires:** on any run that goes through the fan-out (the async path and the foreground
 path used when an iterable kwarg can't be serialized). It does **not** fire for an action with

--- a/docs/superpowers/plans/2026-06-17-on-enqueue-all-hook.md
+++ b/docs/superpowers/plans/2026-06-17-on-enqueue-all-hook.md
@@ -1,0 +1,656 @@
+# `on_enqueue_all` Hook Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a declarative `on_enqueue_all` callback that runs once per fan-out run, after enqueueing completes, receiving the exact enqueued count and an honest per-field sources hash.
+
+**Architecture:** A new DSL method (`on_enqueue_all`) stores blocks in a `_enqueue_all_callbacks` class attribute on the action. `EnqueueAllOrchestrator.execute_iteration` — the single method both the async and foreground enqueue paths funnel through — fires the registered callbacks after `iterate` completes, resolving the sources hash only when callbacks exist. Each block is `instance_exec`-ed on the target action class with arity-filtered kwargs and wrapped in `PipingError.swallow` so a raise never aborts the fan-out.
+
+**Tech Stack:** Ruby, RSpec. Gem: `axn`. No new dependencies.
+
+## Global Constraints
+
+- `spec/` is the **non-Rails** suite — AR/Rails constants must stay guarded via `defined?()`; do not require Rails in `spec/`. Rails-dependent behavior belongs in `spec_rails/`. (This feature is pure Ruby and tests entirely in `spec/`.)
+- Follow existing patterns in `lib/axn/async/`. The `on_*` callback family swallows raised errors via `PipingError.swallow`; `on_enqueue_all` matches that contract and must **not** route to `Axn.config.on_exception`.
+- Block execution context is the **target action class** (`target.instance_exec`), giving the block class-level `log`/`info`/`warn`.
+- The hook fires for runs that pass through `execute_iteration` (async `#call` and the foreground `execute_iteration_without_logging` path). It does **not** fire on the no-`expects` short-circuit at `enqueue_all_orchestrator.rb:60`.
+- Reference spec: `docs/superpowers/specs/2026-06-17-on-enqueue-all-hook-design.md`.
+
+## File Structure
+
+- **Modify** `lib/axn/async/batch_enqueue.rb` — add `_enqueue_all_callbacks` class attribute and the `on_enqueue_all` DSL method (+ YARD docs).
+- **Modify** `lib/axn/async/enqueue_all_orchestrator.rb` — fire callbacks at the end of `execute_iteration`; add private `fire_enqueue_all_callbacks` / `invoke_enqueue_all_callback` helpers.
+- **Modify** `spec/axn/async/batch_enqueue_spec.rb` — full test coverage (registration, count, sources hash, arity, error isolation, no-fire path).
+- **Modify** `docs/reference/async.md` — add a "Run summary with `on_enqueue_all`" subsection under "Batch Enqueueing".
+
+---
+
+### Task 1: DSL — `on_enqueue_all` registration
+
+**Files:**
+- Modify: `lib/axn/async/batch_enqueue.rb`
+- Test: `spec/axn/async/batch_enqueue_spec.rb`
+
+**Interfaces:**
+- Produces: `_enqueue_all_callbacks` class attribute (Array of Procs, default `[]`, inherited by subclasses); class method `on_enqueue_all(&block)` that appends to it and raises `ArgumentError` if no block given.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this `describe` block to `spec/axn/async/batch_enqueue_spec.rb` (place it after the existing top-level `describe "enqueue_all is defined on all Axn classes"` block):
+
+```ruby
+describe "on_enqueue_all DSL registration" do
+  it "registers a callback block" do
+    action_class = build_axn do
+      on_enqueue_all { |count:| count }
+    end
+
+    expect(action_class._enqueue_all_callbacks.size).to eq(1)
+    expect(action_class._enqueue_all_callbacks.first).to be_a(Proc)
+  end
+
+  it "defaults to an empty array" do
+    action_class = build_axn {}
+
+    expect(action_class._enqueue_all_callbacks).to eq([])
+  end
+
+  it "allows multiple callbacks, preserving declaration order" do
+    action_class = build_axn do
+      on_enqueue_all { |count:| "first #{count}" }
+      on_enqueue_all { |count:| "second #{count}" }
+    end
+
+    expect(action_class._enqueue_all_callbacks.size).to eq(2)
+    expect(action_class._enqueue_all_callbacks.map { |cb| cb.call(count: 5) }).to eq(["first 5", "second 5"])
+  end
+
+  it "raises ArgumentError when called without a block" do
+    expect do
+      build_axn { on_enqueue_all }
+    end.to raise_error(ArgumentError, /on_enqueue_all requires a block/)
+  end
+
+  it "does not leak callbacks across sibling classes" do
+    parent = build_axn { on_enqueue_all { |count:| count } }
+    sibling = build_axn {}
+
+    expect(parent._enqueue_all_callbacks.size).to eq(1)
+    expect(sibling._enqueue_all_callbacks).to eq([])
+  end
+end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bundle exec rspec spec/axn/async/batch_enqueue_spec.rb -e "on_enqueue_all DSL registration"`
+Expected: FAIL — `NoMethodError: undefined method 'on_enqueue_all'` / `undefined method '_enqueue_all_callbacks'`.
+
+- [ ] **Step 3: Add the class attribute**
+
+In `lib/axn/async/batch_enqueue.rb`, in the `included do` block, add the attribute alongside the existing one:
+
+```ruby
+included do
+  class_attribute :_batch_enqueue_configs, default: []
+  class_attribute :_enqueue_all_callbacks, default: []
+end
+```
+
+- [ ] **Step 4: Add the DSL method**
+
+In `lib/axn/async/batch_enqueue.rb`, in `module DSL`, add after `enqueues_each`:
+
+```ruby
+# Register a once-per-run callback that fires after the batch fan-out completes.
+#
+# Runs inside EnqueueAllOrchestrator (off the clock thread), after all jobs are
+# enqueued. The block is evaluated in the context of this action class, so it has
+# access to class-level `log`/`info`/`warn`. Multiple declarations are allowed and
+# fire in declaration order.
+#
+# The block may declare any subset of these keyword arguments (or none):
+# @yieldparam count [Integer] exact number of jobs enqueued (post-filter)
+# @yieldparam sources [Hash{Symbol => Object}] resolved (un-materialized) source per
+#   iterated field, e.g. { tax_profile: <relation> } or { user: <rel>, company: <rel> }
+#
+# A raise inside the block is swallowed (logged; re-raised in dev only when
+# `Axn.config.raise_piping_errors_in_dev` is set) and cannot change the enqueue
+# outcome — rescue inside your block if you need stronger guarantees.
+#
+# @example Post a run summary to Slack
+#   on_enqueue_all do |sources:, count:|
+#     active, inactive = sources[:tax_profile].partition { _1.user.active? }
+#     SlackSender.call(channel: :eng_ops, text: "#{active.size} active, #{inactive.size} deactivated (#{count} enqueued)")
+#   end
+#
+# @example Count-only heartbeat
+#   on_enqueue_all { |count:| info "Found #{count} events" }
+def on_enqueue_all(&block)
+  raise ArgumentError, "on_enqueue_all requires a block" unless block
+
+  self._enqueue_all_callbacks += [block]
+end
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `bundle exec rspec spec/axn/async/batch_enqueue_spec.rb -e "on_enqueue_all DSL registration"`
+Expected: PASS (5 examples).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/axn/async/batch_enqueue.rb spec/axn/async/batch_enqueue_spec.rb
+git commit -m "PRO-2743 Add on_enqueue_all DSL registration
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Fire callbacks after fan-out — count + context
+
+**Files:**
+- Modify: `lib/axn/async/enqueue_all_orchestrator.rb`
+- Test: `spec/axn/async/batch_enqueue_spec.rb`
+
+**Interfaces:**
+- Consumes: `target._enqueue_all_callbacks` (from Task 1); existing `execute_iteration`, `Config#resolve_source`, `Axn::Internal::Callable.only_requested_params`, `Axn::Internal::PipingError.swallow`.
+- Produces: private class methods `fire_enqueue_all_callbacks(target:, configs:, count:)` and `invoke_enqueue_all_callback(target:, callback:, sources:, count:)` on `EnqueueAllOrchestrator`; `execute_iteration` now fires callbacks before returning.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this `describe` block to `spec/axn/async/batch_enqueue_spec.rb` (after the cross-product describe, near the other behavioral specs). It reuses the file's `company_class` / `enable_async_on` / `with_synchronous_enqueue_all` helpers:
+
+```ruby
+describe "on_enqueue_all firing" do
+  before { with_synchronous_enqueue_all }
+
+  it "fires once after the fan-out with the exact enqueued count" do
+    captured = []
+    cc = company_class
+    action_class = build_axn do
+      expects :company, type: cc
+      define_method(:call) { company.name }
+      enqueues_each :company, from: -> { cc.all }
+    end.tap { |klass| enable_async_on(klass) }
+    action_class.on_enqueue_all { |count:| captured << count }
+
+    allow(action_class).to receive(:call_async)
+    action_class.enqueue_all
+
+    expect(captured).to eq([3]) # 3 company records, fired once
+  end
+
+  it "reflects the post-filter count when a filter block skips items" do
+    captured = []
+    action_class = build_axn do
+      expects :number
+      enqueues_each :number, from: -> { [1, 2, 3, 4] } do |n|
+        n.even?
+      end
+    end.tap { |klass| enable_async_on(klass) }
+    action_class.on_enqueue_all { |count:| captured << count }
+
+    allow(action_class).to receive(:call_async)
+    action_class.enqueue_all
+
+    expect(captured).to eq([2]) # only 2 and 4 pass the filter
+  end
+
+  it "evaluates the block in the target action class context" do
+    captured = {}
+    cc = company_class
+    action_class = build_axn do
+      expects :company, type: cc
+      define_method(:call) { company.name }
+      enqueues_each :company, from: -> { cc.all }
+    end.tap { |klass| enable_async_on(klass) }
+    action_class.on_enqueue_all { captured[:context] = self }
+
+    allow(action_class).to receive(:call_async)
+    action_class.enqueue_all
+
+    expect(captured[:context]).to eq(action_class)
+  end
+
+  it "exposes class-level logging (info) inside the block without raising" do
+    cc = company_class
+    action_class = build_axn do
+      expects :company, type: cc
+      define_method(:call) { company.name }
+      enqueues_each :company, from: -> { cc.all }
+    end.tap { |klass| enable_async_on(klass) }
+    action_class.on_enqueue_all { |count:| info "enqueued #{count}" }
+
+    allow(action_class).to receive(:call_async)
+
+    expect { action_class.enqueue_all }.not_to raise_error
+  end
+
+  it "fires each registered callback in declaration order" do
+    order = []
+    cc = company_class
+    action_class = build_axn do
+      expects :company, type: cc
+      define_method(:call) { company.name }
+      enqueues_each :company, from: -> { cc.all }
+    end.tap { |klass| enable_async_on(klass) }
+    action_class.on_enqueue_all { order << :first }
+    action_class.on_enqueue_all { order << :second }
+
+    allow(action_class).to receive(:call_async)
+    action_class.enqueue_all
+
+    expect(order).to eq(%i[first second])
+  end
+
+  it "does not fire when no callbacks are registered (no extra source resolution)" do
+    cc = company_class
+    resolve_calls = 0
+    action_class = build_axn do
+      expects :company, type: cc
+      define_method(:call) { company.name }
+      enqueues_each :company, from: -> { resolve_calls += 1; cc.all }
+    end.tap { |klass| enable_async_on(klass) }
+
+    allow(action_class).to receive(:call_async)
+    action_class.enqueue_all
+
+    # Source resolved once for iteration only; the hook adds no extra resolution.
+    expect(resolve_calls).to eq(1)
+  end
+
+  it "does not fire on the no-expects single-job path" do
+    fired = false
+    action_class = build_axn do
+      define_method(:call) { "noop" }
+    end.tap { |klass| enable_async_on(klass) }
+    action_class.on_enqueue_all { fired = true }
+
+    allow(action_class).to receive(:call_async)
+    action_class.enqueue_all # no expects -> enqueue_for short-circuits to call_async, bypassing the orchestrator
+
+    expect(fired).to be(false)
+  end
+end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bundle exec rspec spec/axn/async/batch_enqueue_spec.rb -e "on_enqueue_all firing"`
+Expected: FAIL — callbacks never invoked (`captured` stays empty), so the count/context/order expectations fail. (The "no-expects" example passes from the start — it asserts non-firing — which is fine.)
+
+- [ ] **Step 3: Fire callbacks at the end of `execute_iteration`**
+
+In `lib/axn/async/enqueue_all_orchestrator.rb`, modify `execute_iteration` to fire callbacks before returning:
+
+```ruby
+def execute_iteration(target, on_progress: nil, **static_args)
+  configs, resolved_static = resolve_configs(target, static_args:)
+  count = { value: 0 }
+  iterate(target:, configs:, index: 0, accumulated: {}, static_args: resolved_static, count:, on_progress:)
+  fire_enqueue_all_callbacks(target:, configs:, count: count[:value])
+  count[:value]
+end
+```
+
+- [ ] **Step 4: Add the firing helpers**
+
+In `lib/axn/async/enqueue_all_orchestrator.rb`, add these private class methods (inside `class << self`, e.g. after `execute_iteration_without_logging`):
+
+```ruby
+# Fire any registered on_enqueue_all callbacks once, after the fan-out completes.
+# Resolves the per-field sources hash only when callbacks exist, so actions
+# without the hook pay no extra source resolution.
+def fire_enqueue_all_callbacks(target:, configs:, count:)
+  callbacks = target._enqueue_all_callbacks
+  return if callbacks.empty?
+
+  sources = configs.each_with_object({}) do |config, hash|
+    hash[config.field] = config.resolve_source(target:)
+  end
+
+  callbacks.each { |callback| invoke_enqueue_all_callback(target:, callback:, sources:, count:) }
+end
+
+# Invoke a single callback in the target class context with arity-filtered kwargs.
+# A raise is swallowed (mirrors on_success / filter_block) so the fan-out is never aborted.
+def invoke_enqueue_all_callback(target:, callback:, sources:, count:)
+  args, kwargs = Axn::Internal::Callable.only_requested_params(callback, kwargs: { sources:, count: })
+  target.instance_exec(*args, **kwargs, &callback)
+rescue StandardError => e
+  Axn::Internal::PipingError.swallow("on_enqueue_all callback for #{target.name}", exception: e)
+end
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `bundle exec rspec spec/axn/async/batch_enqueue_spec.rb -e "on_enqueue_all firing"`
+Expected: PASS (7 examples).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/axn/async/enqueue_all_orchestrator.rb spec/axn/async/batch_enqueue_spec.rb
+git commit -m "PRO-2743 Fire on_enqueue_all callbacks after fan-out with count
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `sources:` hash + arity flexibility
+
+**Files:**
+- Test: `spec/axn/async/batch_enqueue_spec.rb`
+
+**Interfaces:**
+- Consumes: the `sources`/`count` payload and `Callable.only_requested_params` filtering wired in Task 2. No production changes — this task proves the contract for the sources hash and arity, and locks it with tests.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this `describe` block to `spec/axn/async/batch_enqueue_spec.rb` (after the "on_enqueue_all firing" block):
+
+```ruby
+describe "on_enqueue_all sources and arity" do
+  before { with_synchronous_enqueue_all }
+
+  it "passes a single-entry sources hash for a single config" do
+    captured = {}
+    cc = company_class
+    action_class = build_axn do
+      expects :company, type: cc
+      define_method(:call) { company.name }
+      enqueues_each :company, from: -> { cc.all }
+    end.tap { |klass| enable_async_on(klass) }
+    action_class.on_enqueue_all { |sources:| captured[:sources] = sources }
+
+    allow(action_class).to receive(:call_async)
+    action_class.enqueue_all
+
+    expect(captured[:sources].keys).to eq([:company])
+    expect(captured[:sources][:company]).to match_array(company_class._records)
+  end
+
+  it "passes an entry per field for a cross-product, with the product count" do
+    captured = {}
+    cc = company_class
+    uc = user_class
+    action_class = build_axn do
+      expects :company, type: cc
+      expects :user, type: uc
+      define_method(:call) { "#{user.name} @ #{company.name}" }
+      enqueues_each :user, from: -> { uc.all }
+      enqueues_each :company, from: -> { cc.active }
+    end.tap { |klass| enable_async_on(klass) }
+    action_class.on_enqueue_all { |sources:, count:| captured[:sources] = sources; captured[:count] = count }
+
+    allow(action_class).to receive(:call_async)
+    action_class.enqueue_all
+
+    expect(captured[:sources].keys).to match_array(%i[user company])
+    expect(captured[:sources][:user]).to match_array(user_class._records)
+    expect(captured[:sources][:company]).to match_array(company_class._records.select(&:active?))
+    expect(captured[:count]).to eq(4) # 2 users × 2 active companies
+  end
+
+  it "reflects a kwarg source override in the sources hash" do
+    captured = {}
+    cc = company_class
+    action_class = build_axn do
+      expects :company, type: cc
+      define_method(:call) { company.name }
+      enqueues_each :company, from: -> { cc.all }
+    end.tap { |klass| enable_async_on(klass) }
+    action_class.on_enqueue_all { |sources:| captured[:sources] = sources }
+
+    allow(action_class).to receive(:call_async)
+    override = [company_class._records.first]
+    action_class.enqueue_all(company: override)
+
+    expect(captured[:sources][:company]).to eq(override)
+  end
+
+  it "invokes a no-argument block" do
+    fired = false
+    cc = company_class
+    action_class = build_axn do
+      expects :company, type: cc
+      define_method(:call) { company.name }
+      enqueues_each :company, from: -> { cc.all }
+    end.tap { |klass| enable_async_on(klass) }
+    action_class.on_enqueue_all { fired = true }
+
+    allow(action_class).to receive(:call_async)
+    action_class.enqueue_all
+
+    expect(fired).to be(true)
+  end
+
+  it "invokes a block that only requests count:" do
+    captured = []
+    cc = company_class
+    action_class = build_axn do
+      expects :company, type: cc
+      define_method(:call) { company.name }
+      enqueues_each :company, from: -> { cc.all }
+    end.tap { |klass| enable_async_on(klass) }
+    action_class.on_enqueue_all { |count:| captured << count }
+
+    allow(action_class).to receive(:call_async)
+    action_class.enqueue_all
+
+    expect(captured).to eq([3])
+  end
+end
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+Run: `bundle exec rspec spec/axn/async/batch_enqueue_spec.rb -e "on_enqueue_all sources and arity"`
+Expected: PASS (5 examples). (If the cross-product or override cases fail, the bug is in Task 2's `fire_enqueue_all_callbacks` source resolution — fix there.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add spec/axn/async/batch_enqueue_spec.rb
+git commit -m "PRO-2743 Cover on_enqueue_all sources hash and arity flexibility
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Error isolation
+
+**Files:**
+- Test: `spec/axn/async/batch_enqueue_spec.rb`
+
+**Interfaces:**
+- Consumes: the `PipingError.swallow` wrapping in `invoke_enqueue_all_callback` (Task 2). No production changes expected — if a test fails, fix `invoke_enqueue_all_callback`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this `describe` block to `spec/axn/async/batch_enqueue_spec.rb` (after the "sources and arity" block). It mirrors the existing "filter block exceptions" specs' use of the `PipingError.swallow` spy:
+
+```ruby
+describe "on_enqueue_all error isolation" do
+  before { with_synchronous_enqueue_all }
+
+  let(:action_class) do
+    cc = company_class
+    build_axn do
+      expects :company, type: cc
+      define_method(:call) { company.name }
+      enqueues_each :company, from: -> { cc.all }
+    end.tap { |klass| enable_async_on(klass) }
+  end
+
+  it "does not abort the fan-out when a callback raises" do
+    action_class.on_enqueue_all { raise "summary exploded" }
+    enqueued = []
+    allow(action_class).to receive(:call_async) { |**args| enqueued << args }
+    allow(Axn::Internal::PipingError).to receive(:swallow).and_call_original
+
+    expect { action_class.enqueue_all }.not_to raise_error
+    expect(enqueued.length).to eq(3) # all jobs still enqueued
+  end
+
+  it "swallows the error via PipingError" do
+    action_class.on_enqueue_all { raise "summary exploded" }
+    allow(action_class).to receive(:call_async)
+
+    expect(Axn::Internal::PipingError).to receive(:swallow).with(
+      a_string_including("on_enqueue_all callback"),
+      exception: an_instance_of(RuntimeError),
+    )
+
+    action_class.enqueue_all
+  end
+
+  it "still fires later callbacks after an earlier one raises" do
+    fired = []
+    action_class.on_enqueue_all { raise "boom" }
+    action_class.on_enqueue_all { fired << :second }
+    allow(action_class).to receive(:call_async)
+    allow(Axn::Internal::PipingError).to receive(:swallow).and_call_original
+
+    action_class.enqueue_all
+
+    expect(fired).to eq([:second])
+  end
+end
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+Run: `bundle exec rspec spec/axn/async/batch_enqueue_spec.rb -e "on_enqueue_all error isolation"`
+Expected: PASS (3 examples). These should pass against Task 2's implementation; if the "later callbacks" test fails, confirm `fire_enqueue_all_callbacks` wraps each callback individually (per-callback rescue), not the whole loop.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add spec/axn/async/batch_enqueue_spec.rb
+git commit -m "PRO-2743 Cover on_enqueue_all error isolation
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Documentation
+
+**Files:**
+- Modify: `docs/reference/async.md`
+
+**Interfaces:** None (docs only).
+
+- [ ] **Step 1: Add the docs subsection**
+
+In `docs/reference/async.md`, under the "Batch Enqueueing with `enqueues_each`" section, add a new subsection immediately before "### Memory Efficiency":
+
+````markdown
+### Run summary with `on_enqueue_all`
+
+`on_enqueue_all` registers a once-per-run callback that fires **after** the batch fan-out
+completes — useful for posting a summary, emitting a metric, or logging a heartbeat without
+hand-rolling a parent wrapper action. It runs inside the orchestrator (off the clock thread),
+in the context of your action class, so class-level `log`/`info`/`warn` are available.
+
+```ruby
+class StockCertificate::EoyTaxReminder
+  include Axn
+  async :sidekiq
+
+  expects :tax_profile, model: TaxProfile
+  enqueues_each :tax_profile, from: -> { TaxProfile.needs_address_validation }
+
+  on_enqueue_all do |sources:, count:|
+    active, inactive = sources[:tax_profile].partition { _1.user.active? }
+    SlackSender.call(channel: :eng_ops, text: "#{active.size} active, #{inactive.size} deactivated (#{count} enqueued)")
+  end
+
+  def call
+    # per-tax-profile work
+  end
+end
+```
+
+The block may declare any subset of these keyword arguments (or none):
+
+- **`count:`** — the exact number of jobs enqueued (post-filter). Always available, including
+  for cross-product runs.
+- **`sources:`** — a hash of `{ field => resolved_source }` for each iterated field, e.g.
+  `{ tax_profile: <relation> }` or, for a cross-product, `{ user: <rel>, company: <rel> }`.
+  Sources are the resolved-but-un-materialized relations (run your own `.count` / `.group` /
+  `.partition`), and reflect any kwarg overrides passed to `enqueue_all`.
+
+```ruby
+# Count-only heartbeat:
+on_enqueue_all { |count:| info "Found #{count} events" }
+```
+
+Multiple `on_enqueue_all` declarations are allowed and fire in declaration order.
+
+**Error handling:** a raise inside the block is swallowed (logged; re-raised in development
+only when `Axn.config.raise_piping_errors_in_dev` is set) and cannot change the enqueue
+outcome — the fan-out has already completed. This matches `on_success` semantics; rescue
+inside your block if you need stronger guarantees.
+
+**When it fires:** on any run that goes through the fan-out (the async path and the foreground
+path used when an iterable kwarg can't be serialized). It does **not** fire for an action with
+no `expects`, which enqueues a single job directly without fanning out.
+````
+
+- [ ] **Step 2: Verify the docs render coherently**
+
+Run: `grep -n "on_enqueue_all" docs/reference/async.md`
+Expected: matches in the new subsection; confirm it sits between "Multi-Field Cross-Product" / "Static Fields" area and "### Memory Efficiency".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/reference/async.md
+git commit -m "PRO-2743 Document on_enqueue_all hook
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Full suite + lint
+
+**Files:** None (verification only).
+
+- [ ] **Step 1: Run the full async/batch suite**
+
+Run: `bundle exec rspec spec/axn/async/batch_enqueue_spec.rb`
+Expected: PASS (all examples, including the 20 new ones).
+
+- [ ] **Step 2: Run the whole non-Rails suite**
+
+Run: `bundle exec rspec spec/`
+Expected: PASS (no regressions).
+
+- [ ] **Step 3: Run RuboCop on changed files**
+
+Run: `bundle exec rubocop lib/axn/async/batch_enqueue.rb lib/axn/async/enqueue_all_orchestrator.rb spec/axn/async/batch_enqueue_spec.rb`
+Expected: no offenses. Fix any style offenses inline (match surrounding conventions), then re-run.
+
+- [ ] **Step 4: Commit any lint fixes (if needed)**
+
+```bash
+git add -A
+git commit -m "PRO-2743 Lint fixes for on_enqueue_all
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Notes for the release follow-up (out of scope for this plan)
+
+- Do **not** bump os-app's lockfile here. Per gem-release convention, a human batches the `axn` release.
+- After release, os-app adoption lands separately: EOY (PRO-2740), buyback (PRO-2737), plus the audit-for-benefit callsites listed in the Linear issue.

--- a/docs/superpowers/specs/2026-06-17-on-enqueue-all-hook-design.md
+++ b/docs/superpowers/specs/2026-06-17-on-enqueue-all-hook-design.md
@@ -1,0 +1,181 @@
+# `on_enqueue_all` — once-per-run fan-out summary hook
+
+**Linear:** [PRO-2743](https://linear.app/teamshares/issue/PRO-2743/axn-pre-fan-out-summary-support)
+**Date:** 2026-06-17
+**Status:** Design approved, ready for implementation plan
+
+## Problem
+
+`enqueues_each` / `enqueue_all` fans out one isolated background job per record, but
+gives the action no hook to run **once-per-run, batch-level work** around the fan-out.
+Today that forces a hand-rolled parent/child wrapper action — the exact boilerplate
+`enqueue_all` is meant to remove.
+
+Motivating cases (from PRO-2735 worker conversions):
+
+- **EOY tax reminders (PRO-2740):** post one Slack message to `:eng_ops` summarizing the
+  resolved batch ("X active, Y deactivated users were potentially reminded") around the
+  fan-out per tax profile. Requires inspecting the source records (active/deactivated split).
+- **Buyback deferment (PRO-2737):** a lightweight "Found N events" summary. Just needs the count.
+
+This ticket adds the affordance upstream in the `axn` gem. The PRO-2735 conversions are
+**not blocked** on it — they ship with summaries dropped and adopt the hook in a follow-up.
+
+## Solution overview
+
+A declarative, once-per-run callback — `on_enqueue_all` — that fires **inside**
+`EnqueueAllOrchestrator`, off the clock thread, **after** the fan-out loop completes.
+It receives the exact enqueued `count:` and an honest `sources:` hash, and is wrapped so a
+raising block can never abort the fan-out.
+
+### DSL
+
+Declared on the action, alongside `enqueues_each`, in `BatchEnqueue::DSL`:
+
+```ruby
+class StockCertificate::EoyTaxReminder
+  include Axn
+  async :sidekiq
+
+  expects :tax_profile, model: TaxProfile
+  enqueues_each :tax_profile, from: -> { TaxProfile.needs_address_validation }
+
+  on_enqueue_all do |sources:, count:|
+    active, inactive = sources[:tax_profile].partition { _1.user.active? }
+    SlackSender.call(
+      channel: :eng_ops,
+      text: "#{active.size} active, #{inactive.size} deactivated users were potentially reminded (#{count} jobs enqueued)",
+    )
+  end
+
+  def call
+    # per-tax-profile work
+  end
+end
+```
+
+Count-only example (arity-flexible — take any subset of the kwargs, or none):
+
+```ruby
+on_enqueue_all { |count:| info "Found #{count} events" }
+```
+
+## Design decisions
+
+### Timing: fires *after* the fan-out loop
+
+The hook fires after `iterate` completes, not before. Rationale:
+
+- The **only** quantity uniformly well-defined across single-source and multi-field
+  cross-product runs is the exact enqueued `count` — and after the loop it is already
+  computed (`count[:value]`). A "pre" hook could only offer `source.count`, which is
+  **meaningless for a cross-product** (you'd be multiplying per-config counts, and a
+  `filter_block` breaks even that).
+- Neither motivating case needs a true pre-work heartbeat: EOY's summary reads fine in
+  past tense, and "Found N" is satisfied by the exact post-filter count.
+
+### Block receives `count:` (always) and `sources:` (honest hash)
+
+- **`count:`** — exact post-filter enqueued total. Always passed. Uniform across single
+  and cross-product runs.
+- **`sources:`** — a hash `{ field => resolved_relation }` with one entry per config:
+  - single config → `{ tax_profile: <relation> }`
+  - cross-product → `{ user: <relation>, company: <relation> }`
+
+  Each value is the config's **resolved but un-materialized** source (e.g. an AR relation),
+  so the block can run its own efficient aggregate (`.count`, `.group`, `.partition` only
+  if it opts in). Because `from:` lambdas are zero-arg, resolving once for the hook is
+  exactly representative of what `iterate` uses.
+
+  **Why a hash, not a scalar `source:`:** a singular `source:` would be `nil` (a lie) in
+  the cross-product case. The hash is always honest. It also reflects kwarg overrides
+  (`enqueue_all(tax_profile: SomeRelation)`) correctly, where a block re-referencing its
+  own declared lambda would silently describe the wrong population.
+
+  `sources` is resolved **only when at least one `on_enqueue_all` callback is registered**,
+  so actions without the hook pay no extra query.
+
+- **Flexible arity** via the gem's existing `Axn::Internal::Callable.only_requested_params`:
+  a block may declare `|sources:|`, `|count:|`, `|sources:, count:|`, `|**opts|`, or no
+  params at all. Same ergonomics as `on_success` et al.
+
+### Storage & multiplicity
+
+- Stored in `class_attribute :_enqueue_all_callbacks, default: []` — inherits to subclasses,
+  same pattern as `_batch_enqueue_configs`.
+- **Multiple `on_enqueue_all` declarations are allowed**, fired in declaration order —
+  consistent with the `on_success`/`on_error`/`on_exception` callback family.
+
+### Execution context: the target action *class*
+
+Each block is `target.instance_exec(...)`-ed on the **target action class** (the class that
+declared `on_enqueue_all`). This:
+
+- gives the block class-level `log`/`info`/`warn` (Axn class-level logging),
+- is semantically the user's own class, and
+- works **identically in both the async and foreground paths**, since both have `target`
+  in scope and neither instantiates the target action.
+
+### Firing location: end of `execute_iteration` (covers both paths)
+
+The hook fires at the end of `EnqueueAllOrchestrator.execute_iteration` (a class method),
+after `iterate` and before returning the count. This single insertion point covers:
+
+- the **async** path: `#call` → `execute_iteration` (orchestrator.rb:33), and
+- the **foreground** path: `enqueue_for` → `execute_iteration_without_logging` →
+  `execute_iteration` (orchestrator.rb:77 → 104), used when an iterable kwarg can't be
+  serialized for background execution.
+
+It does **not** fire on the degenerate no-`expects` single-job path (`enqueue_for`
+short-circuits via `target.call_async` at orchestrator.rb:60) — there is no fan-out to
+summarize. This is documented behavior.
+
+### Error isolation: swallow, mirroring `on_success`
+
+A raising `on_enqueue_all` block must **never** abort the fan-out (the fan-out is the
+important work, and at this point it has already completed — there is nothing to roll back).
+
+Each block invocation is wrapped in `Axn::Internal::PipingError.swallow`, exactly like the
+sibling `filter_block` (orchestrator.rb:279–289) and the `on_success`/`on_error` callbacks
+(which pipe through `Invoker` → `PipingError.swallow`). Behavior:
+
+- **Production / test:** swallowed + `logger.warn`.
+- **Development:** re-raised **only if** `Axn.config.raise_piping_errors_in_dev` is enabled.
+
+We deliberately do **not** route to `Axn.config.on_exception` (Honeybadger): the enqueue
+has already succeeded, so reporting it as an exception would falsely read as "the job
+failed," breaking consistency with the rest of the callback family. A raise here cannot
+change the enqueue outcome — same contract as `on_success`. Users who need stronger
+guarantees rescue inside their own block.
+
+A raise in one block does not prevent the remaining registered blocks from firing.
+
+## Affected files (gem)
+
+- `lib/axn/async/batch_enqueue.rb` — add the `on_enqueue_all` DSL method and the
+  `_enqueue_all_callbacks` class attribute.
+- `lib/axn/async/enqueue_all_orchestrator.rb` — fire the registered callbacks at the end
+  of `execute_iteration`, resolving the `sources` hash (only when callbacks exist).
+
+## Testing
+
+- `spec/axn/async/batch_enqueue_spec.rb` (non-Rails) — DSL registration, multiplicity,
+  arity flexibility, count correctness, `sources` hash shape (single + cross-product),
+  error isolation (swallow + continue, remaining blocks still fire), no-fire on the
+  no-`expects` path.
+- `spec_rails/` dummy app — adoption-shaped coverage where a real AR relation / `find_each`
+  source is needed (e.g. `sources[:field].partition`), confirming un-materialized relations
+  and override-correctness.
+
+(`spec/` is non-Rails; AR/Rails constants must stay guarded. Rails-dependent behavior lives
+in `spec_rails/`.)
+
+## Out of scope
+
+- Post-job-**completion** hooks (would require integrating each backend's lifecycle to know
+  when individual jobs finish). This hook fires when enqueueing completes, not when the
+  fanned-out jobs complete.
+- A pre-fan-out heartbeat firing *before* iteration.
+- Auto-bumping os-app's lockfile. Per gem-release convention, a human batches the release;
+  os-app adoption (PRO-2740, PRO-2737, and the audit-for-benefit callsites) lands as a
+  follow-up after the gem ships.

--- a/lib/axn/async/batch_enqueue.rb
+++ b/lib/axn/async/batch_enqueue.rb
@@ -52,7 +52,6 @@ module Axn
 
       included do
         class_attribute :_batch_enqueue_configs, default: []
-        class_attribute :_enqueue_all_callbacks, default: []
       end
 
       # DSL methods for batch enqueueing
@@ -98,18 +97,23 @@ module Axn
         # Register a once-per-run callback that fires after the batch fan-out completes.
         #
         # Runs inside EnqueueAllOrchestrator (off the clock thread), after all jobs are
-        # enqueued. The block is evaluated in the context of this action class, so it has
-        # access to class-level `log`/`info`/`warn`. Multiple declarations are allowed and
-        # fire in declaration order.
+        # enqueued. The handler is evaluated in the context of this action class, so it has
+        # access to class-level `log`/`info`/`warn` (a Symbol handler resolves to a class
+        # method). Like the other `on_*` callbacks, this accepts a block or a Symbol method
+        # name, supports `if:`/`unless:`, and — when multiple are declared — fires them
+        # most-recent-first (last-defined wins).
         #
-        # The block may declare any subset of these keyword arguments (or none):
+        # The handler may declare any subset of these keyword arguments (or none):
         # @yieldparam count [Integer] exact number of jobs enqueued (post-filter)
         # @yieldparam sources [Hash{Symbol => Object}] resolved (un-materialized) source per
         #   iterated field, e.g. { tax_profile: <relation> } or { user: <rel>, company: <rel> }
         #
-        # A raise inside the block is swallowed (logged; re-raised in dev only when
+        # Note: `if:`/`unless:` conditions are evaluated like the other callbacks' matchers
+        # (against the action with no exception); they cannot observe `sources`/`count`.
+        #
+        # A raise inside the handler is swallowed (logged; re-raised in dev only when
         # `Axn.config.raise_piping_errors_in_dev` is set) and cannot change the enqueue
-        # outcome — rescue inside your block if you need stronger guarantees.
+        # outcome — rescue inside your handler if you need stronger guarantees.
         #
         # @example Post a run summary to Slack
         #   on_enqueue_all do |sources:, count:|
@@ -117,13 +121,10 @@ module Axn
         #     SlackSender.call(channel: :eng_ops, text: "#{active.size} active, #{inactive.size} deactivated (#{count} enqueued)")
         #   end
         #
-        # @example Count-only heartbeat
-        #   on_enqueue_all { |count:| info "Found #{count} events" }
-        def on_enqueue_all(&block)
-          raise ArgumentError, "on_enqueue_all requires a block" unless block
-
-          self._enqueue_all_callbacks += [block]
-        end
+        # @example Count-only heartbeat via a class method
+        #   on_enqueue_all :log_summary
+        #   def self.log_summary(count:) = info "Found #{count} events"
+        def on_enqueue_all(handler = nil, **, &block) = _add_callback(:enqueue_all, handler:, **, block:)
       end
     end
   end

--- a/lib/axn/async/batch_enqueue.rb
+++ b/lib/axn/async/batch_enqueue.rb
@@ -52,6 +52,7 @@ module Axn
 
       included do
         class_attribute :_batch_enqueue_configs, default: []
+        class_attribute :_enqueue_all_callbacks, default: []
       end
 
       # DSL methods for batch enqueueing
@@ -92,6 +93,36 @@ module Axn
         # @param block [Proc, nil] Optional filter block - return truthy to enqueue, falsy to skip
         def enqueues_each(field, from: nil, via: nil, &filter_block)
           self._batch_enqueue_configs += [Config.new(field:, from:, via:, filter_block:)]
+        end
+
+        # Register a once-per-run callback that fires after the batch fan-out completes.
+        #
+        # Runs inside EnqueueAllOrchestrator (off the clock thread), after all jobs are
+        # enqueued. The block is evaluated in the context of this action class, so it has
+        # access to class-level `log`/`info`/`warn`. Multiple declarations are allowed and
+        # fire in declaration order.
+        #
+        # The block may declare any subset of these keyword arguments (or none):
+        # @yieldparam count [Integer] exact number of jobs enqueued (post-filter)
+        # @yieldparam sources [Hash{Symbol => Object}] resolved (un-materialized) source per
+        #   iterated field, e.g. { tax_profile: <relation> } or { user: <rel>, company: <rel> }
+        #
+        # A raise inside the block is swallowed (logged; re-raised in dev only when
+        # `Axn.config.raise_piping_errors_in_dev` is set) and cannot change the enqueue
+        # outcome — rescue inside your block if you need stronger guarantees.
+        #
+        # @example Post a run summary to Slack
+        #   on_enqueue_all do |sources:, count:|
+        #     active, inactive = sources[:tax_profile].partition { _1.user.active? }
+        #     SlackSender.call(channel: :eng_ops, text: "#{active.size} active, #{inactive.size} deactivated (#{count} enqueued)")
+        #   end
+        #
+        # @example Count-only heartbeat
+        #   on_enqueue_all { |count:| info "Found #{count} events" }
+        def on_enqueue_all(&block)
+          raise ArgumentError, "on_enqueue_all requires a block" unless block
+
+          self._enqueue_all_callbacks += [block]
         end
       end
     end

--- a/lib/axn/async/enqueue_all_orchestrator.rb
+++ b/lib/axn/async/enqueue_all_orchestrator.rb
@@ -94,6 +94,7 @@ module Axn
           configs, resolved_static = resolve_configs(target, static_args:)
           count = { value: 0 }
           iterate(target:, configs:, index: 0, accumulated: {}, static_args: resolved_static, count:, on_progress:)
+          fire_enqueue_all_callbacks(target:, configs:, count: count[:value])
           count[:value]
         end
 
@@ -107,6 +108,29 @@ module Axn
         end
 
         private
+
+        # Fire any registered on_enqueue_all callbacks once, after the fan-out completes.
+        # Resolves the per-field sources hash only when callbacks exist, so actions
+        # without the hook pay no extra source resolution.
+        def fire_enqueue_all_callbacks(target:, configs:, count:)
+          callbacks = target._enqueue_all_callbacks
+          return if callbacks.empty?
+
+          sources = configs.each_with_object({}) do |config, hash|
+            hash[config.field] = config.resolve_source(target:)
+          end
+
+          callbacks.each { |callback| invoke_enqueue_all_callback(target:, callback:, sources:, count:) }
+        end
+
+        # Invoke a single callback in the target class context with arity-filtered kwargs.
+        # A raise is swallowed (mirrors on_success / filter_block) so the fan-out is never aborted.
+        def invoke_enqueue_all_callback(target:, callback:, sources:, count:)
+          args, kwargs = Axn::Internal::Callable.only_requested_params(callback, kwargs: { sources:, count: })
+          target.instance_exec(*args, **kwargs, &callback)
+        rescue StandardError => e
+          Axn::Internal::PipingError.swallow("on_enqueue_all callback for #{target.name}", exception: e)
+        end
 
         # Builds iteration sources and resolves static args from kwargs
         #

--- a/lib/axn/async/enqueue_all_orchestrator.rb
+++ b/lib/axn/async/enqueue_all_orchestrator.rb
@@ -123,35 +123,60 @@ module Axn
           descriptors = target._callbacks_registry.for(:enqueue_all).select { |d| d.matches?(action: target, exception: nil) }
           return if descriptors.empty?
 
+          # Lazy + memoized: resolve the sources hash only when a callback actually requests
+          # `sources:` (count-only callbacks skip it entirely), and only once across callbacks.
+          # The thunk is invoked INSIDE invoke_enqueue_all_callback's rescue so a failed second
+          # resolution (non-repeatable source / transient DB or API error) is swallowed like any
+          # other hook error — it must never propagate out of execute_iteration after the fan-out
+          # has already enqueued, which would fail the orchestrator and retry/duplicate the batch.
+          #
           # NOTE: deliberately re-resolves each source (a second, un-materialized resolution
-          # distinct from iterate's). Keep it lazy/un-materialized — do not cache iterate's
-          # source here, or the hook would force materialization and break the relation contract.
-          sources = configs.each_with_object({}) do |config, hash|
-            hash[config.field] = config.resolve_source(target:)
+          # distinct from iterate's). Keep it un-materialized — do not cache iterate's source
+          # here, or the hook would force materialization and break the relation contract.
+          sources = nil
+          resolve_sources = lambda do
+            sources ||= configs.each_with_object({}) do |config, hash|
+              hash[config.field] = config.resolve_source(target:)
+            end
           end
 
-          descriptors.each { |descriptor| invoke_enqueue_all_callback(target:, handler: descriptor.handler, sources:, count:) }
+          descriptors.each { |descriptor| invoke_enqueue_all_callback(target:, handler: descriptor.handler, resolve_sources:, count:) }
         end
 
         # Invoke a single callback handler in the target class context with arity-filtered
         # kwargs. A Symbol handler resolves to a class method on the target; a callable is
-        # instance_exec'd on the class. A raise is swallowed (mirrors on_success / filter_block)
-        # so the fan-out is never aborted.
-        def invoke_enqueue_all_callback(target:, handler:, sources:, count:)
+        # instance_exec'd on the class. The sources hash is resolved (via resolve_sources) only
+        # if the handler requests it. A raise — from the handler OR from resolving sources — is
+        # swallowed (mirrors on_success / filter_block) so the fan-out is never aborted.
+        def invoke_enqueue_all_callback(target:, handler:, resolve_sources:, count:)
           if handler.is_a?(Symbol)
             unless target.respond_to?(handler, true)
               target.warn("Ignoring apparently-invalid on_enqueue_all symbol #{handler.inspect} -- class does not respond to method")
               return
             end
+            callable = target.method(handler)
+          else
+            callable = handler
+          end
 
-            args, kwargs = Axn::Internal::Callable.only_requested_params(target.method(handler), kwargs: { sources:, count: })
+          available = { count: }
+          available[:sources] = resolve_sources.call if requests_param?(callable, :sources)
+          args, kwargs = Axn::Internal::Callable.only_requested_params(callable, kwargs: available)
+
+          if handler.is_a?(Symbol)
             target.send(handler, *args, **kwargs)
           else
-            args, kwargs = Axn::Internal::Callable.only_requested_params(handler, kwargs: { sources:, count: })
             target.instance_exec(*args, **kwargs, &handler)
           end
         rescue StandardError => e
           Axn::Internal::PipingError.swallow("on_enqueue_all callback for #{target.name}", exception: e)
+        end
+
+        # Whether a callable accepts a given keyword (directly or via **kwargs / keyrest).
+        def requests_param?(callable, name)
+          callable.parameters.any? do |type, param_name|
+            type == :keyrest || (%i[key keyreq].include?(type) && param_name == name)
+          end
         end
 
         # Builds iteration sources and resolves static args from kwargs

--- a/lib/axn/async/enqueue_all_orchestrator.rb
+++ b/lib/axn/async/enqueue_all_orchestrator.rb
@@ -110,11 +110,18 @@ module Axn
         private
 
         # Fire any registered on_enqueue_all callbacks once, after the fan-out completes.
-        # Resolves the per-field sources hash only when callbacks exist, so actions
-        # without the hook pay no extra source resolution.
+        # Callbacks live in the shared callbacks registry (event_type :enqueue_all), so they
+        # reuse the on_* family's registration, validation, if:/unless: matching, and
+        # last-defined-wins ordering. Execution stays bespoke here because the shared Invoker
+        # is exception-shaped and cannot carry the sources:/count: payload.
+        #
+        # Resolves the per-field sources hash only when an applicable callback exists, so
+        # actions without the hook (or whose if:/unless: all fail) pay no extra source resolution.
         def fire_enqueue_all_callbacks(target:, configs:, count:)
-          callbacks = target._enqueue_all_callbacks
-          return if callbacks.empty?
+          # NOTE: matchers (if:/unless:) are exception-shaped; pass exception: nil. They can
+          # condition on class-level state but cannot observe sources/count.
+          descriptors = target._callbacks_registry.for(:enqueue_all).select { |d| d.matches?(action: target, exception: nil) }
+          return if descriptors.empty?
 
           # NOTE: deliberately re-resolves each source (a second, un-materialized resolution
           # distinct from iterate's). Keep it lazy/un-materialized — do not cache iterate's
@@ -123,14 +130,26 @@ module Axn
             hash[config.field] = config.resolve_source(target:)
           end
 
-          callbacks.each { |callback| invoke_enqueue_all_callback(target:, callback:, sources:, count:) }
+          descriptors.each { |descriptor| invoke_enqueue_all_callback(target:, handler: descriptor.handler, sources:, count:) }
         end
 
-        # Invoke a single callback in the target class context with arity-filtered kwargs.
-        # A raise is swallowed (mirrors on_success / filter_block) so the fan-out is never aborted.
-        def invoke_enqueue_all_callback(target:, callback:, sources:, count:)
-          args, kwargs = Axn::Internal::Callable.only_requested_params(callback, kwargs: { sources:, count: })
-          target.instance_exec(*args, **kwargs, &callback)
+        # Invoke a single callback handler in the target class context with arity-filtered
+        # kwargs. A Symbol handler resolves to a class method on the target; a callable is
+        # instance_exec'd on the class. A raise is swallowed (mirrors on_success / filter_block)
+        # so the fan-out is never aborted.
+        def invoke_enqueue_all_callback(target:, handler:, sources:, count:)
+          if handler.is_a?(Symbol)
+            unless target.respond_to?(handler, true)
+              target.warn("Ignoring apparently-invalid on_enqueue_all symbol #{handler.inspect} -- class does not respond to method")
+              return
+            end
+
+            args, kwargs = Axn::Internal::Callable.only_requested_params(target.method(handler), kwargs: { sources:, count: })
+            target.send(handler, *args, **kwargs)
+          else
+            args, kwargs = Axn::Internal::Callable.only_requested_params(handler, kwargs: { sources:, count: })
+            target.instance_exec(*args, **kwargs, &handler)
+          end
         rescue StandardError => e
           Axn::Internal::PipingError.swallow("on_enqueue_all callback for #{target.name}", exception: e)
         end

--- a/lib/axn/async/enqueue_all_orchestrator.rb
+++ b/lib/axn/async/enqueue_all_orchestrator.rb
@@ -116,6 +116,9 @@ module Axn
           callbacks = target._enqueue_all_callbacks
           return if callbacks.empty?
 
+          # NOTE: deliberately re-resolves each source (a second, un-materialized resolution
+          # distinct from iterate's). Keep it lazy/un-materialized — do not cache iterate's
+          # source here, or the hook would force materialization and break the relation contract.
           sources = configs.each_with_object({}) do |config, hash|
             hash[config.field] = config.resolve_source(target:)
           end

--- a/spec/axn/async/batch_enqueue_spec.rb
+++ b/spec/axn/async/batch_enqueue_spec.rb
@@ -1004,4 +1004,96 @@ RSpec.describe "Axn::Async::BatchEnqueue" do
       expect(fired).to be(false)
     end
   end
+
+  describe "on_enqueue_all sources and arity" do
+    before { with_synchronous_enqueue_all }
+
+    it "passes a single-entry sources hash for a single config" do
+      captured = {}
+      cc = company_class
+      action_class = build_axn do
+        expects :company, type: cc
+        define_method(:call) { company.name }
+        enqueues_each :company, from: -> { cc.all }
+      end.tap { |klass| enable_async_on(klass) }
+      action_class.on_enqueue_all { |sources:| captured[:sources] = sources }
+
+      allow(action_class).to receive(:call_async)
+      action_class.enqueue_all
+
+      expect(captured[:sources].keys).to eq([:company])
+      expect(captured[:sources][:company]).to match_array(company_class._records)
+    end
+
+    it "passes an entry per field for a cross-product, with the product count" do
+      captured = {}
+      cc = company_class
+      uc = user_class
+      action_class = build_axn do
+        expects :company, type: cc
+        expects :user, type: uc
+        define_method(:call) { "#{user.name} @ #{company.name}" }
+        enqueues_each :user, from: -> { uc.all }
+        enqueues_each :company, from: -> { cc.active }
+      end.tap { |klass| enable_async_on(klass) }
+      action_class.on_enqueue_all { |sources:, count:| captured[:sources] = sources; captured[:count] = count }
+
+      allow(action_class).to receive(:call_async)
+      action_class.enqueue_all
+
+      expect(captured[:sources].keys).to match_array(%i[user company])
+      expect(captured[:sources][:user]).to match_array(user_class._records)
+      expect(captured[:sources][:company]).to match_array(company_class._records.select(&:active?))
+      expect(captured[:count]).to eq(4) # 2 users × 2 active companies
+    end
+
+    it "reflects a kwarg source override in the sources hash" do
+      captured = {}
+      cc = company_class
+      action_class = build_axn do
+        expects :company, type: cc
+        define_method(:call) { company.name }
+        enqueues_each :company, from: -> { cc.all }
+      end.tap { |klass| enable_async_on(klass) }
+      action_class.on_enqueue_all { |sources:| captured[:sources] = sources }
+
+      allow(action_class).to receive(:call_async)
+      override = [company_class._records.first]
+      action_class.enqueue_all(company: override)
+
+      expect(captured[:sources][:company]).to eq(override)
+    end
+
+    it "invokes a no-argument block" do
+      fired = false
+      cc = company_class
+      action_class = build_axn do
+        expects :company, type: cc
+        define_method(:call) { company.name }
+        enqueues_each :company, from: -> { cc.all }
+      end.tap { |klass| enable_async_on(klass) }
+      action_class.on_enqueue_all { fired = true }
+
+      allow(action_class).to receive(:call_async)
+      action_class.enqueue_all
+
+      expect(fired).to be(true)
+    end
+
+    it "invokes a block that only requests count:" do
+      captured = []
+      cc = company_class
+      action_class = build_axn do
+        expects :company, type: cc
+        define_method(:call) { company.name }
+        enqueues_each :company, from: -> { cc.all }
+      end.tap { |klass| enable_async_on(klass) }
+      action_class.on_enqueue_all { |count:| captured << count }
+
+      allow(action_class).to receive(:call_async)
+      action_class.enqueue_all
+
+      expect(captured).to eq([3])
+    end
+  end
 end

--- a/spec/axn/async/batch_enqueue_spec.rb
+++ b/spec/axn/async/batch_enqueue_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Axn::Async::BatchEnqueue" do
       end
 
       # Handle no-expects case
-      return target.call_async(**static_args) if target.internal_field_configs.empty?
+      next target.call_async(**static_args) if target.internal_field_configs.empty?
 
       # Use the real resolve_configs method to get configs and resolved static args
       configs, resolved_static = Axn::Async::EnqueueAllOrchestrator.send(:resolve_configs, target, static_args:)
@@ -890,6 +890,118 @@ RSpec.describe "Axn::Async::BatchEnqueue" do
         expect(progress_calls).to include(a_hash_including(stage: :iterating, field: :company))
         expect(progress_calls.last).to include(stage: :enqueueing)
       end
+    end
+  end
+
+  describe "on_enqueue_all firing" do
+    before { with_synchronous_enqueue_all }
+
+    it "fires once after the fan-out with the exact enqueued count" do
+      captured = []
+      cc = company_class
+      action_class = build_axn do
+        expects :company, type: cc
+        define_method(:call) { company.name }
+        enqueues_each :company, from: -> { cc.all }
+      end.tap { |klass| enable_async_on(klass) }
+      action_class.on_enqueue_all { |count:| captured << count }
+
+      allow(action_class).to receive(:call_async)
+      action_class.enqueue_all
+
+      expect(captured).to eq([3]) # 3 company records, fired once
+    end
+
+    it "reflects the post-filter count when a filter block skips items" do
+      captured = []
+      action_class = build_axn do
+        expects :number
+        enqueues_each :number, from: -> { [1, 2, 3, 4] } do |n|
+          n.even?
+        end
+      end.tap { |klass| enable_async_on(klass) }
+      action_class.on_enqueue_all { |count:| captured << count }
+
+      allow(action_class).to receive(:call_async)
+      action_class.enqueue_all
+
+      expect(captured).to eq([2]) # only 2 and 4 pass the filter
+    end
+
+    it "evaluates the block in the target action class context" do
+      captured = {}
+      cc = company_class
+      action_class = build_axn do
+        expects :company, type: cc
+        define_method(:call) { company.name }
+        enqueues_each :company, from: -> { cc.all }
+      end.tap { |klass| enable_async_on(klass) }
+      action_class.on_enqueue_all { captured[:context] = self }
+
+      allow(action_class).to receive(:call_async)
+      action_class.enqueue_all
+
+      expect(captured[:context]).to eq(action_class)
+    end
+
+    it "exposes class-level logging (info) inside the block without raising" do
+      cc = company_class
+      action_class = build_axn do
+        expects :company, type: cc
+        define_method(:call) { company.name }
+        enqueues_each :company, from: -> { cc.all }
+      end.tap { |klass| enable_async_on(klass) }
+      action_class.on_enqueue_all { |count:| info "enqueued #{count}" }
+
+      allow(action_class).to receive(:call_async)
+
+      expect { action_class.enqueue_all }.not_to raise_error
+    end
+
+    it "fires each registered callback in declaration order" do
+      order = []
+      cc = company_class
+      action_class = build_axn do
+        expects :company, type: cc
+        define_method(:call) { company.name }
+        enqueues_each :company, from: -> { cc.all }
+      end.tap { |klass| enable_async_on(klass) }
+      action_class.on_enqueue_all { order << :first }
+      action_class.on_enqueue_all { order << :second }
+
+      allow(action_class).to receive(:call_async)
+      action_class.enqueue_all
+
+      expect(order).to eq(%i[first second])
+    end
+
+    it "does not fire when no callbacks are registered (no extra source resolution)" do
+      cc = company_class
+      resolve_calls = 0
+      action_class = build_axn do
+        expects :company, type: cc
+        define_method(:call) { company.name }
+        enqueues_each :company, from: -> { resolve_calls += 1; cc.all }
+      end.tap { |klass| enable_async_on(klass) }
+
+      allow(action_class).to receive(:call_async)
+      action_class.enqueue_all
+
+      # Source resolved once for iteration only; the hook adds no extra resolution.
+      expect(resolve_calls).to eq(1)
+    end
+
+    it "does not fire on the no-expects single-job path" do
+      fired = false
+      action_class = build_axn do
+        define_method(:call) { "noop" }
+      end.tap { |klass| enable_async_on(klass) }
+      action_class.on_enqueue_all { fired = true }
+
+      allow(action_class).to receive(:call_async)
+      action_class.enqueue_all # no expects -> enqueue_for short-circuits to call_async, bypassing the orchestrator
+
+      expect(fired).to be(false)
     end
   end
 end

--- a/spec/axn/async/batch_enqueue_spec.rb
+++ b/spec/axn/async/batch_enqueue_spec.rb
@@ -1061,6 +1061,54 @@ RSpec.describe "Axn::Async::BatchEnqueue" do
       expect(resolve_calls).to eq(1)
     end
 
+    it "does not re-resolve sources for a count-only callback" do
+      cc = company_class
+      resolve_calls = 0
+      action_class = build_axn do
+        expects :company, type: cc
+        define_method(:call) { company.name }
+        enqueues_each :company, from: lambda {
+          resolve_calls += 1
+          cc.all
+        }
+      end.tap { |klass| enable_async_on(klass) }
+      action_class.on_enqueue_all { |count:| count } # never requests sources:
+
+      allow(action_class).to receive(:call_async)
+      action_class.enqueue_all
+
+      # Iteration resolves once; a count-only callback triggers no second resolution.
+      expect(resolve_calls).to eq(1)
+    end
+
+    it "swallows a failed post-fan-out source re-resolution without aborting the fan-out" do
+      cc = company_class
+      resolve_calls = 0
+      action_class = build_axn do
+        expects :company, type: cc
+        define_method(:call) { company.name }
+        # Succeeds during iteration (call 1); raises on the hook's second resolution (call 2).
+        enqueues_each :company, from: lambda {
+          resolve_calls += 1
+          raise "transient source failure" if resolve_calls > 1
+
+          cc.all
+        }
+      end.tap { |klass| enable_async_on(klass) }
+      action_class.on_enqueue_all { |sources:| sources[:company].to_a } # requests sources -> triggers re-resolution
+
+      enqueued = []
+      allow(action_class).to receive(:call_async) { |**args| enqueued << args }
+      expect(Axn::Internal::PipingError).to receive(:swallow).with(
+        a_string_including("on_enqueue_all callback"),
+        exception: an_instance_of(RuntimeError),
+      )
+
+      # Must not propagate: a raise here would fail the orchestrator and retry/duplicate the batch.
+      expect { action_class.enqueue_all }.not_to raise_error
+      expect(enqueued.length).to eq(3) # all jobs still enqueued
+    end
+
     it "does not fire on the no-expects single-job path" do
       fired = false
       action_class = build_axn do

--- a/spec/axn/async/batch_enqueue_spec.rb
+++ b/spec/axn/async/batch_enqueue_spec.rb
@@ -1096,4 +1096,51 @@ RSpec.describe "Axn::Async::BatchEnqueue" do
       expect(captured).to eq([3])
     end
   end
+
+  describe "on_enqueue_all error isolation" do
+    before { with_synchronous_enqueue_all }
+
+    let(:action_class) do
+      cc = company_class
+      build_axn do
+        expects :company, type: cc
+        define_method(:call) { company.name }
+        enqueues_each :company, from: -> { cc.all }
+      end.tap { |klass| enable_async_on(klass) }
+    end
+
+    it "does not abort the fan-out when a callback raises" do
+      action_class.on_enqueue_all { raise "summary exploded" }
+      enqueued = []
+      allow(action_class).to receive(:call_async) { |**args| enqueued << args }
+      allow(Axn::Internal::PipingError).to receive(:swallow).and_call_original
+
+      expect { action_class.enqueue_all }.not_to raise_error
+      expect(enqueued.length).to eq(3) # all jobs still enqueued
+    end
+
+    it "swallows the error via PipingError" do
+      action_class.on_enqueue_all { raise "summary exploded" }
+      allow(action_class).to receive(:call_async)
+
+      expect(Axn::Internal::PipingError).to receive(:swallow).with(
+        a_string_including("on_enqueue_all callback"),
+        exception: an_instance_of(RuntimeError),
+      )
+
+      action_class.enqueue_all
+    end
+
+    it "still fires later callbacks after an earlier one raises" do
+      fired = []
+      action_class.on_enqueue_all { raise "boom" }
+      action_class.on_enqueue_all { fired << :second }
+      allow(action_class).to receive(:call_async)
+      allow(Axn::Internal::PipingError).to receive(:swallow).and_call_original
+
+      action_class.enqueue_all
+
+      expect(fired).to eq([:second])
+    end
+  end
 end

--- a/spec/axn/async/batch_enqueue_spec.rb
+++ b/spec/axn/async/batch_enqueue_spec.rb
@@ -114,43 +114,62 @@ RSpec.describe "Axn::Async::BatchEnqueue" do
   end
 
   describe "on_enqueue_all DSL registration" do
-    it "registers a callback block" do
+    def enqueue_all_callbacks_for(klass) = klass._callbacks_registry.for(:enqueue_all)
+
+    it "registers a callback block in the shared callbacks registry" do
       action_class = build_axn do
         on_enqueue_all { |count:| count }
       end
 
-      expect(action_class._enqueue_all_callbacks.size).to eq(1)
-      expect(action_class._enqueue_all_callbacks.first).to be_a(Proc)
+      expect(enqueue_all_callbacks_for(action_class).size).to eq(1)
+      expect(enqueue_all_callbacks_for(action_class).first.handler).to be_a(Proc)
     end
 
-    it "defaults to an empty array" do
+    it "registers a Symbol handler" do
+      action_class = build_axn do
+        def self.summarize(count:) = count
+        on_enqueue_all :summarize
+      end
+
+      expect(enqueue_all_callbacks_for(action_class).size).to eq(1)
+      expect(enqueue_all_callbacks_for(action_class).first.handler).to eq(:summarize)
+    end
+
+    it "defaults to no registered callbacks" do
       action_class = build_axn {}
 
-      expect(action_class._enqueue_all_callbacks).to eq([])
+      expect(enqueue_all_callbacks_for(action_class)).to eq([])
     end
 
-    it "allows multiple callbacks, preserving declaration order" do
+    it "registers multiple callbacks (registry orders them last-defined-first)" do
       action_class = build_axn do
         on_enqueue_all { |count:| "first #{count}" }
         on_enqueue_all { |count:| "second #{count}" }
       end
 
-      expect(action_class._enqueue_all_callbacks.size).to eq(2)
-      expect(action_class._enqueue_all_callbacks.map { |cb| cb.call(count: 5) }).to eq(["first 5", "second 5"])
+      handlers = enqueue_all_callbacks_for(action_class).map(&:handler)
+      expect(handlers.size).to eq(2)
+      expect(handlers.map { |cb| cb.call(count: 5) }).to eq(["second 5", "first 5"])
     end
 
-    it "raises ArgumentError when called without a block" do
+    it "raises ArgumentError when called with neither a block nor a handler" do
       expect do
         build_axn { on_enqueue_all }
-      end.to raise_error(ArgumentError, /on_enqueue_all requires a block/)
+      end.to raise_error(ArgumentError, /on_enqueue_all must be called with a block or symbol/)
+    end
+
+    it "raises ArgumentError when called with both a block and a handler" do
+      expect do
+        build_axn { on_enqueue_all(:summarize) { |count:| count } }
+      end.to raise_error(ArgumentError, /on_enqueue_all cannot be called with both a block and a handler/)
     end
 
     it "does not leak callbacks across sibling classes" do
       parent = build_axn { on_enqueue_all { |count:| count } }
       sibling = build_axn {}
 
-      expect(parent._enqueue_all_callbacks.size).to eq(1)
-      expect(sibling._enqueue_all_callbacks).to eq([])
+      expect(enqueue_all_callbacks_for(parent).size).to eq(1)
+      expect(enqueue_all_callbacks_for(sibling)).to eq([])
     end
   end
 
@@ -956,7 +975,7 @@ RSpec.describe "Axn::Async::BatchEnqueue" do
       expect { action_class.enqueue_all }.not_to raise_error
     end
 
-    it "fires each registered callback in declaration order" do
+    it "fires each registered callback, most-recent-first (last-defined wins)" do
       order = []
       cc = company_class
       action_class = build_axn do
@@ -970,7 +989,57 @@ RSpec.describe "Axn::Async::BatchEnqueue" do
       allow(action_class).to receive(:call_async)
       action_class.enqueue_all
 
-      expect(order).to eq(%i[first second])
+      expect(order).to eq(%i[second first])
+    end
+
+    it "invokes a Symbol handler as a class method with arity-filtered kwargs" do
+      cc = company_class
+      action_class = build_axn do
+        expects :company, type: cc
+        define_method(:call) { company.name }
+        enqueues_each :company, from: -> { cc.all }
+        def self.captured = @captured ||= {}
+        def self.record_summary(count:) = captured[:count] = count
+        on_enqueue_all :record_summary
+      end.tap { |klass| enable_async_on(klass) }
+
+      allow(action_class).to receive(:call_async)
+      action_class.enqueue_all
+
+      expect(action_class.captured[:count]).to eq(3)
+    end
+
+    it "warns and skips a Symbol handler the class does not respond to" do
+      cc = company_class
+      action_class = build_axn do
+        expects :company, type: cc
+        define_method(:call) { company.name }
+        enqueues_each :company, from: -> { cc.all }
+        on_enqueue_all :missing_method
+      end.tap { |klass| enable_async_on(klass) }
+
+      allow(action_class).to receive(:call_async)
+      expect(action_class).to receive(:warn).with(/Ignoring apparently-invalid on_enqueue_all symbol :missing_method/)
+
+      expect { action_class.enqueue_all }.not_to raise_error
+    end
+
+    it "respects if:/unless: conditions" do
+      fired = []
+      cc = company_class
+      action_class = build_axn do
+        expects :company, type: cc
+        define_method(:call) { company.name }
+        enqueues_each :company, from: -> { cc.all }
+        def self.should_summarize? = true
+      end.tap { |klass| enable_async_on(klass) }
+      action_class.on_enqueue_all(if: :should_summarize?) { fired << :if_true }
+      action_class.on_enqueue_all(unless: :should_summarize?) { fired << :unless_true }
+
+      allow(action_class).to receive(:call_async)
+      action_class.enqueue_all
+
+      expect(fired).to eq([:if_true])
     end
 
     it "does not fire when no callbacks are registered (no extra source resolution)" do

--- a/spec/axn/async/batch_enqueue_spec.rb
+++ b/spec/axn/async/batch_enqueue_spec.rb
@@ -113,6 +113,47 @@ RSpec.describe "Axn::Async::BatchEnqueue" do
     end
   end
 
+  describe "on_enqueue_all DSL registration" do
+    it "registers a callback block" do
+      action_class = build_axn do
+        on_enqueue_all { |count:| count }
+      end
+
+      expect(action_class._enqueue_all_callbacks.size).to eq(1)
+      expect(action_class._enqueue_all_callbacks.first).to be_a(Proc)
+    end
+
+    it "defaults to an empty array" do
+      action_class = build_axn {}
+
+      expect(action_class._enqueue_all_callbacks).to eq([])
+    end
+
+    it "allows multiple callbacks, preserving declaration order" do
+      action_class = build_axn do
+        on_enqueue_all { |count:| "first #{count}" }
+        on_enqueue_all { |count:| "second #{count}" }
+      end
+
+      expect(action_class._enqueue_all_callbacks.size).to eq(2)
+      expect(action_class._enqueue_all_callbacks.map { |cb| cb.call(count: 5) }).to eq(["first 5", "second 5"])
+    end
+
+    it "raises ArgumentError when called without a block" do
+      expect do
+        build_axn { on_enqueue_all }
+      end.to raise_error(ArgumentError, /on_enqueue_all requires a block/)
+    end
+
+    it "does not leak callbacks across sibling classes" do
+      parent = build_axn { on_enqueue_all { |count:| count } }
+      sibling = build_axn {}
+
+      expect(parent._enqueue_all_callbacks.size).to eq(1)
+      expect(sibling._enqueue_all_callbacks).to eq([])
+    end
+  end
+
   describe "single field iteration" do
     describe "with explicit from:" do
       let(:action_class) do

--- a/spec/axn/async/batch_enqueue_spec.rb
+++ b/spec/axn/async/batch_enqueue_spec.rb
@@ -1065,6 +1065,7 @@ RSpec.describe "Axn::Async::BatchEnqueue" do
       override = [company_class._records.first]
       action_class.enqueue_all(company: override)
 
+      expect(captured).to have_key(:sources)
       expect(captured[:sources][:company]).to eq(override)
     end
 

--- a/spec/axn/async/batch_enqueue_spec.rb
+++ b/spec/axn/async/batch_enqueue_spec.rb
@@ -916,9 +916,7 @@ RSpec.describe "Axn::Async::BatchEnqueue" do
       captured = []
       action_class = build_axn do
         expects :number
-        enqueues_each :number, from: -> { [1, 2, 3, 4] } do |n|
-          n.even?
-        end
+        enqueues_each :number, from: -> { [1, 2, 3, 4] }, &:even?
       end.tap { |klass| enable_async_on(klass) }
       action_class.on_enqueue_all { |count:| captured << count }
 
@@ -981,7 +979,10 @@ RSpec.describe "Axn::Async::BatchEnqueue" do
       action_class = build_axn do
         expects :company, type: cc
         define_method(:call) { company.name }
-        enqueues_each :company, from: -> { resolve_calls += 1; cc.all }
+        enqueues_each :company, from: lambda {
+          resolve_calls += 1
+          cc.all
+        }
       end.tap { |klass| enable_async_on(klass) }
 
       allow(action_class).to receive(:call_async)
@@ -1036,7 +1037,10 @@ RSpec.describe "Axn::Async::BatchEnqueue" do
         enqueues_each :user, from: -> { uc.all }
         enqueues_each :company, from: -> { cc.active }
       end.tap { |klass| enable_async_on(klass) }
-      action_class.on_enqueue_all { |sources:, count:| captured[:sources] = sources; captured[:count] = count }
+      action_class.on_enqueue_all do |sources:, count:|
+        captured[:sources] = sources
+        captured[:count] = count
+      end
 
       allow(action_class).to receive(:call_async)
       action_class.enqueue_all

--- a/spec_rails/dummy_app/spec/axn/mountable/enqueue_all_spec.rb
+++ b/spec_rails/dummy_app/spec/axn/mountable/enqueue_all_spec.rb
@@ -186,4 +186,71 @@ RSpec.describe "Axn::Async::BatchEnqueue with Sidekiq" do
       expect(result).to eq("job-id")
     end
   end
+
+  describe "on_enqueue_all with a real ActiveRecord relation" do
+    before do
+      Profile.delete_all
+      User.delete_all
+      User.create!(name: "Active A", email: "a@example.com")
+      User.create!(name: "Active B", email: "b@example.com")
+      User.create!(name: "Deactivated", email: nil)
+    end
+
+    after do
+      Profile.delete_all
+      User.delete_all
+    end
+
+    it "hands the block an un-materialized relation supporting efficient aggregation" do
+      captured = {}
+      action_class = Class.new do
+        include Axn
+        async :sidekiq
+        expects :user, model: User
+        def call; end
+        enqueues_each :user, from: -> { User.all }
+      end
+      action_class.on_enqueue_all do |sources:, count:|
+        relation = sources[:user]
+        captured[:is_relation] = relation.is_a?(ActiveRecord::Relation)
+        captured[:loaded_before_use] = relation.loaded? # must be false: un-materialized contract
+        captured[:db_count] = relation.count            # aggregate COUNT query, no full load
+        active, inactive = relation.partition { |u| u.email.present? }
+        captured[:active] = active.size
+        captured[:inactive] = inactive.size
+        captured[:count] = count
+      end
+
+      allow(action_class).to receive(:call_async)
+      Axn::Async::EnqueueAllOrchestrator.execute_iteration(action_class)
+
+      expect(captured[:is_relation]).to be(true)
+      expect(captured[:loaded_before_use]).to be(false)
+      expect(captured[:db_count]).to eq(3)
+      expect(captured[:active]).to eq(2)
+      expect(captured[:inactive]).to eq(1)
+      expect(captured[:count]).to eq(3) # exact enqueued count via find_each
+    end
+
+    it "reflects a scoped-relation kwarg override in the sources hash" do
+      captured = {}
+      action_class = Class.new do
+        include Axn
+        async :sidekiq
+        expects :user, model: User
+        def call; end
+        enqueues_each :user, from: -> { User.all }
+      end
+      action_class.on_enqueue_all do |sources:, count:|
+        captured[:emails] = sources[:user].pluck(:email)
+        captured[:count] = count
+      end
+
+      allow(action_class).to receive(:call_async)
+      Axn::Async::EnqueueAllOrchestrator.execute_iteration(action_class, user: User.where.not(email: nil))
+
+      expect(captured[:emails]).to contain_exactly("a@example.com", "b@example.com")
+      expect(captured[:count]).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
## What

Adds a declarative `on_enqueue_all` callback that runs **once per fan-out run**, after enqueueing completes, inside `EnqueueAllOrchestrator` (off the clock thread). It gives `enqueues_each`/`enqueue_all` actions a place to do batch-level work (post a Slack summary, emit a metric, log a heartbeat) without hand-rolling a parent wrapper action.

```ruby
class StockCertificate::EoyTaxReminder
  include Axn
  async :sidekiq

  expects :tax_profile, model: TaxProfile
  enqueues_each :tax_profile, from: -> { TaxProfile.needs_address_validation }

  on_enqueue_all do |sources:, count:|
    active, inactive = sources[:tax_profile].partition { _1.user.active? }
    SlackSender.call(channel: :eng_ops, text: "#{active.size} active, #{inactive.size} deactivated (#{count} enqueued)")
  end

  def call
    # per-tax-profile work
  end
end
```

## Design

- **Fires after the fan-out loop**, at the single point (`execute_iteration`) both the async `#call` path and the foreground `execute_iteration_without_logging` path funnel through. Does **not** fire on the no-`expects` single-job short-circuit.
- The block receives any subset of:
  - **`count:`** — exact post-filter enqueued total; uniform across single-source and cross-product runs.
  - **`sources:`** — honest hash `{ field => resolved_relation }` per iterated field. Resolved **only when a callback is registered**, un-materialized (run your own `.count`/`.group`/`.partition`), and reflects kwarg source overrides.
- Flexible arity via the gem's existing `Callable.only_requested_params`.
- Evaluated via `target.instance_exec` (the action class), so `log`/`info`/`warn` are available.
- **Error isolation:** a raising block is swallowed via `PipingError.swallow` (mirrors `on_success`/`filter_block`) — it never aborts the fan-out and is not routed to `on_exception`. Re-raises in dev only when `raise_piping_errors_in_dev` is set. Multiple declarations fire in order; one raising callback doesn't stop the others.

Why "after" rather than a true pre-fan-out hook: the only quantity uniformly well-defined across single-source and cross-product runs is the exact `count`, which is only known once iteration completes. `source.count` is meaningless for a cross-product.

Design spec and implementation plan are included under `docs/superpowers/`.

## Tests

- `spec/axn/async/batch_enqueue_spec.rb` — 20 new examples: DSL registration/multiplicity/inheritance, firing + exact count, target-class context, sources hash (single + cross-product + override), arity flexibility, error isolation, and the no-`expects` non-firing path.
- `spec_rails/dummy_app/spec/axn/mountable/enqueue_all_spec.rb` — 2 new examples locking the un-materialized `ActiveRecord::Relation` contract (`loaded?` is false when handed to the block; `.count`/`.partition` work; `find_each` yields the exact count; scoped-relation override is honored).

## Rollout

Per gem-release convention this doesn't bump os-app's lockfile. After release, os-app adoption lands separately: EOY (PRO-2740), buyback (PRO-2737), plus the audit-for-benefit callsites in the Linear issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)