### PR TITLE
PRO-2749 Add AGENTS.md + pre-commit RuboCop hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Lint staged Ruby files with RuboCop before each commit.
+# Fast by design (staged files only); CI runs the full suite (rake rubocop + specs).
+# Installed via `git config core.hooksPath .githooks` — see bin/setup.
+#
+# Skip once with `git commit --no-verify` when you really need to.
+set -euo pipefail
+
+files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(rb|rake|gemspec)$' || true)
+[ -z "$files" ] && exit 0
+
+echo "[pre-commit] RuboCop on staged Ruby files…"
+# --force-exclusion so files passed explicitly still honor the .rubocop.yml Exclude list.
+echo "$files" | xargs bundle exec rubocop --force-exclusion

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,95 @@
+# AGENTS.md
+
+Guidance for agents working in **Axn**. Read before writing code.
+
+## The bar
+
+Axn is the base layer for service objects — the `expects` / `exposes` / `call` contract that
+business logic is written against. It's infrastructure, not app code: a subtle bug here is a bug
+everywhere.
+
+North star: **Axn should be good enough to belong in Rails itself** — the obvious default for
+service objects, the way `ActiveRecord` is for persistence. Write every line as if headed for
+`rails/rails` as an `ActiveAction`. In priority order:
+
+1. **Correctness** — prove behavior with tests; reason about edges explicitly.
+2. **A predictable base layer** — surprising behavior is a defect even when "working as coded."
+3. **An interface that feels inevitable** — optimize for the reader of the *calling* code, then for
+   clear failure messages, then for our own convenience — in that order.
+
+Concise, elegant Ruby is the means; cleverness that costs clarity or predictability is not elegant.
+
+We're in **alpha with internal (Teamshares) users only**, iterating deliberately *so that* we can
+cut a stable mainline release. So: breaking changes are acceptable now but never casual — make them
+on purpose, document them, and prefer additive designs that won't need breaking later. The habits
+that earn a stable base (backward-compatible seams, deprecation over removal) start now.
+
+## Non-negotiables
+
+- **Works outside Rails.** No hard dependency on Rails being loaded — guard every Rails/ActiveRecord
+  reference with `defined?(...)`. `spec/` runs without Rails; `spec_rails/dummy_app/` is the Rails
+  app. Rails-adjacent changes are tested in **both**.
+- **TDD** (`CONTRIBUTING.md`): failing test first, then implementation. Bugfixes start with a
+  reproducing test.
+- **Reuse the seams** — `FieldResolvers` (`:extract`/`:model`), the memoization helpers,
+  `resolve_parent`, the `*_field_configs` collections. A parallel path is a new thing to keep
+  consistent forever.
+- **Additive at the seam.** Extending a config/option keeps the existing canonical key/behavior
+  identical and adds the new axis alongside, so existing consumers are untouched.
+
+## Ruby style (the conventions a linter won't catch)
+
+Formatting is enforced in CI — match the surrounding code and don't spend effort on it. Beyond that:
+
+- Endless methods for one-liners (`def call = expose(...)`); `Data.define` for value objects.
+- Internal helpers prefixed `_`; framework state double-underscored (`@__context`) so user actions
+  can't clobber it; internal-only classes under `Axn::Internal`.
+- Refactor before exceeding a metric limit; if genuinely unavoidable, add a **scoped**
+  `# rubocop:disable <Cop>`, never a blanket one.
+
+## DSL & API patterns
+
+- **Fail at declaration, not runtime.** DSL misuse (bad option combos, reserved names, collisions)
+  `raise`s when the class is *defined*, with a message saying how to fix it. Never silently ignore
+  an option.
+- **Programmer error vs bad data.** Impossible declarations / contradictory calls → `ArgumentError`
+  or `InboundValidationError` (dev-facing). Malformed runtime input a caller could legitimately send
+  → contract validation. Pick the error by who's at fault.
+- **Inferred behavior defers; explicit conflicts raise.** Anything Axn generates automatically (a
+  derived reader, an applied default) yields to a same-named thing the user wrote, leaving a `debug`
+  breadcrumb — it never clobbers silently. A conflict between two things the user *explicitly*
+  declared raises loudly.
+- **Don't force false uniformity, but do fix real inconsistency.** Paths may differ when inputs
+  differ (symbol-keyed kwargs vs indifferent-access nested data). But a value with a uniform
+  *meaning* (`<field>_id` is always the primary key) must be honored on every path, blank/edge
+  inputs included.
+
+## Errors
+
+Reuse the hierarchy in `lib/axn/exceptions.rb`; don't invent ad-hoc classes. Every `message`
+explains the problem **and** the fix (see `UnknownExposure`). New messages meet that bar.
+
+## Testing
+
+- Cover happy path, guard/raise paths, and awkward edges (blank vs nil vs absent, aliasing, nesting,
+  both-supplied conflicts) — that's where base-layer bugs hide.
+- Use `Axn::Testing::SpecHelpers`' `build_axn { ... }`. Non-Rails specs use plain POROs with a
+  finder for `model:` behavior; mirror Rails-specific behavior in `spec_rails/dummy_app/`.
+- Run `bundle exec rspec` and the relevant `spec_rails` specs; verify against real output before
+  claiming done.
+
+## Changes & compatibility
+
+- **CHANGELOG every user-visible change** under `## Unreleased`, tagged `[FEAT]` / `[BREAKING]` /
+  `[BUGFIX]` / `[INTERNAL]` — dense and specific (what, why, edge behavior), matching the prevailing
+  detail level.
+- **`[BREAKING]`**: state old vs new explicitly; if a silent old behavior becomes a raise, say so
+  loudly. Prefer a non-breaking design when one exists.
+- **Comments explain *why*, not *what*** — justify the non-obvious choice; skip comments that restate
+  the code.
+
+## Review feedback
+
+Fresh-context, adversarial review catches real base-layer bugs. Verify each point against the code —
+don't reflexively agree or dismiss. Disagree with evidence; when a reviewer is right, fix it and add
+the regression test. "Fixed" is true only once that test passes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](AGENTS.md) for guidance on working in this repo.

--- a/bin/setup
+++ b/bin/setup
@@ -5,4 +5,7 @@ set -vx
 
 bundle install
 
+# Route git hooks to the tracked .githooks/ directory (pre-commit RuboCop lint).
+git config core.hooksPath .githooks
+
 # Do any other automated setup that you need to do here


### PR DESCRIPTION
Adds an agent-facing contributor guide and a lightweight pre-commit lint hook.

## AGENTS.md
A concise, in-context guide for agents (and humans) working in Axn. It frames the project's north star — Axn as a **stable, predictable base layer** aiming to be worthy of becoming Rails' default service-object path (an `ActiveAction`) — with correctness, predictability, and an inevitable-feeling interface as the ordered priorities. Below the ethos it captures the conventions and DSL/API patterns that recur in the contract layer (fail-at-declaration, programmer-error vs bad-data, inferred-defers/explicit-collides, works-outside-Rails, reuse-the-seams, CHANGELOG discipline).

Deliberately terse: it's loaded into context every run, so it omits anything a linter/CI already enforces (formatting, frozen-string comments, etc.) and sticks to judgment a tool can't supply.

`CLAUDE.md` is a one-line pointer to `AGENTS.md` so Claude Code auto-loads it.

## Pre-commit hook
`.githooks/pre-commit` runs RuboCop on staged `.rb`/`.rake`/`.gemspec` files only (fast); the full `rake rubocop` + spec suites still run in CI. Wired via `git config core.hooksPath .githooks` in `bin/setup` so it installs on a fresh clone. No new gem dependency (chose `core.hooksPath` over overcommit/lefthook). `--no-verify` is the escape hatch.

## Manual verification
- Run `bin/setup` (or `git config core.hooksPath .githooks`) to activate the hook locally — it's auto-set for clones going forward but existing checkouts need it once.