### PR TITLE
docs: broaden code-focus affordance across examples

### DIFF
--- a/docs/advanced/mountable.md
+++ b/docs/advanced/mountable.md
@@ -315,7 +315,7 @@ class DataProcessor
   error "Data processing failed"
 
   # Inherit only error messages, nothing else
-  step :validate, inherit: { fields: false, messages: true } do
+  step :validate, inherit: { fields: false, messages: true } do # [!code focus]
     fail! "Invalid data"  # Will use parent's error message format
   end
 end
@@ -335,7 +335,7 @@ class ApiClient
   end
 
   # Inherit hooks but not callbacks
-  mount_axn :fetch_data, inherit: { hooks: true, callbacks: false } do
+  mount_axn :fetch_data, inherit: { hooks: true, callbacks: false } do # [!code focus]
     # Will run authenticate before
     # Will NOT run log_success callback
   end
@@ -351,7 +351,7 @@ class Workflow
   before :setup
 
   # Steps default to :none, but we can override to inherit lifecycle
-  step :special_step, inherit: :lifecycle do
+  step :special_step, inherit: :lifecycle do # [!code focus]
     # Will run setup hook (unusual for a step)
   end
 end

--- a/docs/advanced/profiling.md
+++ b/docs/advanced/profiling.md
@@ -47,7 +47,7 @@ class UserCreation
   include Axn
 
   # Always profile this action
-  use :vernier
+  use :vernier # [!code focus]
 
   expects :user_params
 
@@ -73,7 +73,7 @@ class DataProcessing
   include Axn
 
   # Profile only when processing large datasets
-  use :vernier, if: -> { record_count > 1000 }
+  use :vernier, if: -> { record_count > 1000 } # [!code focus]
 
   expects :records, :record_count
 
@@ -90,7 +90,7 @@ class DataProcessing
   include Axn
 
   # Profile using a method
-  use :vernier, if: :should_profile?
+  use :vernier, if: :should_profile? # [!code focus]
 
   expects :records, :record_count, :debug_mode, type: :boolean, default: false
 
@@ -144,7 +144,7 @@ class MyAction
   include Axn
 
   # Custom output directory
-  use :vernier, output_dir: Rails.root.join("tmp", "profiles", Rails.env)
+  use :vernier, output_dir: Rails.root.join("tmp", "profiles", Rails.env) # [!code focus]
 
   def call
     # Action logic
@@ -161,7 +161,7 @@ class ComplexAction
   include Axn
 
   # Profile when debug mode is enabled OR when processing admin users
-  use :vernier, if: -> { debug_mode || user.admin? }
+  use :vernier, if: -> { debug_mode || user.admin? } # [!code focus]
 
   expects :user, :debug_mode, type: :boolean, default: false
 
@@ -257,7 +257,7 @@ class OrderProcessing
   include Axn
 
   # Profile only expensive operations
-  use :vernier, if: -> { order.total > 1000 }
+  use :vernier, if: -> { order.total > 1000 } # [!code focus]
 
   expects :order
 
@@ -332,7 +332,7 @@ class MyAction
   include Axn
 
   # Profiling with custom options
-  use :vernier, sample_rate: 0.1
+  use :vernier, sample_rate: 0.1 # [!code focus]
 
   def call
     # Action logic

--- a/docs/recipes/gem-configuration.md
+++ b/docs/recipes/gem-configuration.md
@@ -8,7 +8,7 @@ If your gem needs its own settings, you can declare them with the same machinery
 module Axn::MCP
   extend Axn::Configurable
 
-  setting :mcp_text_content, default: :structured, one_of: %i[structured message]
+  setting :mcp_text_content, default: :structured, one_of: %i[structured message] # [!code focus]
 end
 ```
 

--- a/docs/recipes/memoization.md
+++ b/docs/recipes/memoization.md
@@ -24,11 +24,11 @@ class GenerateReport
 
   private
 
-  memo def top_products
+  memo def top_products # [!code focus]
     company.products.order(sales_count: :desc).limit(10)
   end
 
-  memo def total_revenue
+  memo def total_revenue # [!code focus]
     company.orders.sum(:total)
   end
 end
@@ -69,7 +69,7 @@ class CalculatePricing
 
   private
 
-  memo def price_for(tier)
+  memo def price_for(tier) # [!code focus]
     # Complex pricing calculation...
     PricingEngine.calculate(product, tier:)
   end
@@ -106,7 +106,7 @@ class SyncUserData
   private
 
   # Called multiple times - only fetches once
-  memo def external_data
+  memo def external_data # [!code focus]
     ExternalApi.fetch_user_data(user.external_id)
   end
 

--- a/docs/recipes/suppressing-duplicate-async-reports.md
+++ b/docs/recipes/suppressing-duplicate-async-reports.md
@@ -19,7 +19,7 @@ Add a known key when calling your error reporter from `on_exception`:
 Axn.configure do |c|
   c.on_exception = proc do |e, action:, context:|
     # Tag this notice as Axn-authored so we can identify it in before_notify filters
-    Honeybadger.notify(e, context: context.merge(axn: true))
+    Honeybadger.notify(e, context: context.merge(axn: true)) # [!code focus]
   end
 end
 ```

--- a/docs/reference/async.md
+++ b/docs/reference/async.md
@@ -208,7 +208,7 @@ class SyncForCompany
   include Axn
   async :sidekiq
 
-  expects :company, model: Company
+  expects :company, model: Company # [!code focus]
 
   def call
     puts "Syncing data for company: #{company.name}"
@@ -238,7 +238,7 @@ class SyncForCompany
   include Axn
   async :sidekiq
 
-  expects :company, model: Company  # Auto-inferred: Company.all
+  expects :company, model: Company  # Auto-inferred: Company.all # [!code focus]
 
   def call
     # ... sync logic
@@ -374,7 +374,7 @@ class SyncForUserAndCompany
     # ... sync logic for user + company combination
   end
 
-  enqueues_each :user, from: -> { User.active }
+  enqueues_each :user, from: -> { User.active } # [!code focus:2]
   enqueues_each :company, from: -> { Company.active }
 end
 
@@ -392,7 +392,7 @@ class SyncWithMode
   include Axn
   async :sidekiq
 
-  expects :company, model: Company  # Auto-inferred, will iterate
+  expects :company, model: Company  # Auto-inferred, will iterate # [!code focus:2]
   expects :sync_mode                 # Static, must be provided
 
   def call
@@ -423,7 +423,7 @@ class StockCertificate::EoyTaxReminder
   expects :tax_profile, model: TaxProfile
   enqueues_each :tax_profile, from: -> { TaxProfile.needs_address_validation }
 
-  on_enqueue_all do |sources:, count:|
+  on_enqueue_all do |sources:, count:| # [!code focus:4]
     active, inactive = sources[:tax_profile].partition { _1.user.active? }
     SlackSender.call(channel: :eng_ops, text: "#{active.size} active, #{inactive.size} deactivated (#{count} enqueued)")
   end

--- a/docs/reference/async/active-job.md
+++ b/docs/reference/async/active-job.md
@@ -96,7 +96,7 @@ class PaymentAction
 
   def call
     # This will NOT trigger retries - job completes immediately
-    fail! "Card declined" if card_declined?
+    fail! "Card declined" if card_declined? # [!code focus]
   end
 end
 ```
@@ -118,7 +118,7 @@ class SyncAction
 
   def call
     # This WILL trigger retries (if NetworkError)
-    raise NetworkError, "Connection timeout"
+    raise NetworkError, "Connection timeout" # [!code focus]
   end
 end
 ```
@@ -199,7 +199,7 @@ class MyAction
   include Axn
 
   async :active_job do
-    discard_on ValidationError  # Will trigger on_exception when discarded
+    discard_on ValidationError  # Will trigger on_exception when discarded # [!code focus:2]
     retry_on NetworkError, attempts: 3  # Will trigger on_exception when exhausted
   end
 

--- a/docs/reference/async/sidekiq.md
+++ b/docs/reference/async/sidekiq.md
@@ -139,7 +139,7 @@ class PaymentAction
 
   def call
     # This will NOT trigger retries - job completes immediately
-    fail! "Card declined" if card_declined?
+    fail! "Card declined" if card_declined? # [!code focus]
   end
 end
 ```
@@ -159,7 +159,7 @@ class SyncAction
 
   def call
     # This WILL trigger retries
-    raise NetworkError, "Connection timeout"
+    raise NetworkError, "Connection timeout" # [!code focus]
   end
 end
 ```

--- a/docs/reference/class.md
+++ b/docs/reference/class.md
@@ -29,9 +29,9 @@ class MyAction
   include Axn
 
   expects :include_pii, type: :boolean
-  expects :ssn, sensitive: -> { !include_pii }
+  expects :ssn, sensitive: -> { !include_pii } # [!code focus]
 
-  exposes :api_response, sensitive: :should_redact?
+  exposes :api_response, sensitive: :should_redact? # [!code focus]
 
   def call
     expose api_response: fetch_data

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -106,7 +106,7 @@ class ProcessPendingRecords
 
   def call
     pending_records.each do |record|
-      set_execution_context(current_record_id: record.id, batch_index: @index)
+      set_execution_context(current_record_id: record.id, batch_index: @index) # [!code focus]
       # ... process record ...
     end
   end
@@ -128,7 +128,7 @@ class ProcessPendingRecords
 
   private
 
-  def additional_execution_context
+  def additional_execution_context # [!code focus:8]
     return {} unless @current_record
 
     {
@@ -149,7 +149,7 @@ Action-specific `on_exception` handlers can access the full context by calling `
 class ProcessPendingRecords
   include Axn
 
-  on_exception do |exception:|
+  on_exception do |exception:| # [!code focus:3]
     ctx = execution_context
     log "Failed processing. Inputs: #{ctx[:inputs]}, Extra: #{ctx[:current_record_id]}"
     # ... handle exception with context ...
@@ -300,7 +300,7 @@ When using background jobs, you may want different loggers for web requests vs. 
 ```ruby
 Axn.configure do |c|
   # Use Sidekiq's logger when running in Sidekiq workers, otherwise use Rails logger
-  c.logger = (defined?(Sidekiq) && Sidekiq.server?) ? Sidekiq.logger : Rails.logger
+  c.logger = (defined?(Sidekiq) && Sidekiq.server?) ? Sidekiq.logger : Rails.logger # [!code focus]
 end
 ```
 

--- a/docs/strategies/client.md
+++ b/docs/strategies/client.md
@@ -55,7 +55,7 @@ The client strategy automatically configures these middleware:
 class ExternalApiAction
   include Axn
 
-  use :client, name: :api_client, url: "https://api.example.com"
+  use :client, name: :api_client, url: "https://api.example.com" # [!code focus:2]
   use :client, name: :auth_client, url: "https://auth.example.com"
 
   def call
@@ -76,7 +76,7 @@ class SecureApiAction
 
   use :client,
     url: "https://api.example.com",
-    headers: -> { { "Authorization" => "Bearer #{current_token}" } }
+    headers: -> { { "Authorization" => "Bearer #{current_token}" } } # [!code focus]
 
   private
 

--- a/docs/strategies/form.md
+++ b/docs/strategies/form.md
@@ -97,7 +97,7 @@ class ProcessOrder
   include Axn
 
   # Read from :order_params, expose as :order_form
-  use :form, expect: :order_params, expose: :order_form, type: OrderForm
+  use :form, expect: :order_params, expose: :order_form, type: OrderForm # [!code focus]
 
   def call
     # Access via order_form instead of form
@@ -115,7 +115,7 @@ class UpdateProfile
   include Axn
 
   expects :user, model: User
-  use :form, type: ProfileForm, inject: [:user]
+  use :form, type: ProfileForm, inject: [:user] # [!code focus]
 
   def call
     user.update!(form.to_h)
@@ -191,7 +191,7 @@ class CreateUser
 
   use :form, type: CreateUser::Form
 
-  error { form.errors.full_messages.to_sentence }
+  error { form.errors.full_messages.to_sentence } # [!code focus]
 
   def call
     User.create!(form.to_h)

--- a/docs/strategies/index.md
+++ b/docs/strategies/index.md
@@ -21,7 +21,7 @@ To use a strategy in your action, call the `use` method with the strategy name:
 class CreateUser
   include Axn
 
-  use :transaction
+  use :transaction # [!code focus]
 
   expects :email, :name
 
@@ -41,7 +41,7 @@ Some strategies support configuration options. These strategies have a `configur
 class ProcessPayment
   include Axn
 
-  use :retry, max_attempts: 3, backoff: :exponential
+  use :retry, max_attempts: 3, backoff: :exponential # [!code focus]
 
   expects :amount, :card_token
 
@@ -88,7 +88,7 @@ Now you can use it in your actions:
 class MyAction
   include Axn
 
-  use :my_custom
+  use :my_custom # [!code focus]
 
   def call
     # Your action implementation

--- a/docs/strategies/transaction.md
+++ b/docs/strategies/transaction.md
@@ -6,7 +6,7 @@ The `transaction` strategy wraps your action execution in a database transaction
 class TransferFunds
   include Axn
 
-  use :transaction
+  use :transaction # [!code focus]
 
   expects :from_account, :to_account, :amount
 

--- a/docs/usage/setup.md
+++ b/docs/usage/setup.md
@@ -29,7 +29,7 @@ When using Axn in a Rails application, you can configure how actions are autoloa
 # config/initializers/axn.rb
 Axn.configure do |c|
   # Use :Actions namespace to differentiate from existing service objects
-  c.rails.app_actions_autoload_namespace = :Actions
+  c.rails.app_actions_autoload_namespace = :Actions # [!code focus]
 end
 ```
 

--- a/docs/usage/steps.md
+++ b/docs/usage/steps.md
@@ -107,7 +107,7 @@ class UserRegistration
   exposes :user_id, :welcome_message
 
   # Use existing action classes as steps
-  steps(ValidateInput, CreateUser, SendWelcome)
+  steps(ValidateInput, CreateUser, SendWelcome) # [!code focus]
 end
 ```
 


### PR DESCRIPTION
## What & why

Expands VitePress [code focus](https://vitepress.dev/guide/markdown#colored-diffs-in-code-blocks) (`# [!code focus]`) usage across the docs so each full-class / `Axn.configure` example spotlights the 1–3 lines the surrounding prose is actually teaching — the rest of the scaffold blurs until hover, keeping the reader's eye on the point.

Independent of the VitePress 2.0 upgrade (#115); this is content-only and touches no deps/config.

## Approach (selective by design)

Only **full-scaffold** blocks (`class … include Axn … end` or `Axn.configure do … end`) where a couple of lines carry the lesson get annotated. Deliberately **skipped**:
- tight snippets where every line is load-bearing
- complete worked examples where the whole block is the lesson
- ❌Bad / ✅Good contrast pairs
- anything where focusing would light up the majority of the block (blur adds nothing there)

This keeps the affordance meaningful rather than spraying it everywhere. Pre-existing focus annotations are preserved.

## Scope
- 16 files, 43 lines changed — **43 insertions / 43 deletions**, i.e. every change is an in-place line-suffix addition. No code, prose, or formatting altered.
- ~38 new focus annotations (e.g. the lone `use :transaction` / `use :vernier` / `memo def …` / teaching `expects` line in each example).

## Verification
- `yarn docs:build` passes; all annotations well-formed (no malformed/double markers).
- Spot-checked edited pages render correctly on the dev server.