### PR TITLE
PRO-2789: Enable verify_partial_doubles + fix dead/stale spec stubs

### DIFF
--- a/spec/axn/async/adapters/active_job_spec.rb
+++ b/spec/axn/async/adapters/active_job_spec.rb
@@ -58,7 +58,10 @@ RSpec.describe "Axn::Async with ActiveJob adapter" do
 
   describe ".call_async" do
     it "calls perform_later on the proxy class with context" do
-      expect_any_instance_of(Class).to receive(:perform_later).with({ name: "World", age: 25 })
+      proxy_class = double("proxy")
+      allow(action_class).to receive(:active_job_proxy_class).and_return(proxy_class)
+
+      expect(proxy_class).to receive(:perform_later).with({ name: "World", age: 25 })
       action_class.call_async(name: "World", age: 25)
     end
 
@@ -83,12 +86,18 @@ RSpec.describe "Axn::Async with ActiveJob adapter" do
       end
 
       it "calls perform_later when _async is not a hash" do
-        expect_any_instance_of(Class).to receive(:perform_later).with({ name: "World", age: 25, _async: "user_value" })
+        proxy_class = double("proxy")
+        allow(action_class).to receive(:active_job_proxy_class).and_return(proxy_class)
+
+        expect(proxy_class).to receive(:perform_later).with({ name: "World", age: 25, _async: "user_value" })
         action_class.call_async(name: "World", age: 25, _async: "user_value")
       end
 
       it "calls perform_later when _async is an empty hash" do
-        expect_any_instance_of(Class).to receive(:perform_later).with({ name: "World", age: 25 })
+        proxy_class = double("proxy")
+        allow(action_class).to receive(:active_job_proxy_class).and_return(proxy_class)
+
+        expect(proxy_class).to receive(:perform_later).with({ name: "World", age: 25 })
         action_class.call_async(name: "World", age: 25, _async: {})
       end
     end
@@ -105,7 +114,10 @@ RSpec.describe "Axn::Async with ActiveJob adapter" do
     end
 
     it "calls perform_later on the proxy class with context" do
-      expect_any_instance_of(Class).to receive(:perform_later).with({ name: "World", age: 25 })
+      proxy_class = double("proxy")
+      allow(action_class).to receive(:active_job_proxy_class).and_return(proxy_class)
+
+      expect(proxy_class).to receive(:perform_later).with({ name: "World", age: 25 })
       action_class.call_async(name: "World", age: 25)
     end
 

--- a/spec/axn/async/adapters/sidekiq/auto_configure_spec.rb
+++ b/spec/axn/async/adapters/sidekiq/auto_configure_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe Axn::Async::Adapters::Sidekiq::AutoConfigure do
     described_class.reset!
   end
 
+  # Sidekiq isn't a dependency of this suite, so we fake the constant. Declaring
+  # #configure_server lets verify_partial_doubles confirm the stubbed method exists.
+  let(:fake_sidekiq) do
+    Module.new { def self.configure_server; end }
+  end
+
   describe ".registered?" do
     it "returns false initially" do
       expect(described_class.registered?).to be false
@@ -18,7 +24,7 @@ RSpec.describe Axn::Async::Adapters::Sidekiq::AutoConfigure do
 
     it "returns true after register!" do
       # Mock Sidekiq
-      stub_const("Sidekiq", Module.new)
+      stub_const("Sidekiq", fake_sidekiq)
       allow(Sidekiq).to receive(:configure_server).and_yield(double(
                                                                server_middleware: ->(&block) { block.call(double(add: nil, any?: false)) },
                                                                death_handlers: [],
@@ -31,7 +37,7 @@ RSpec.describe Axn::Async::Adapters::Sidekiq::AutoConfigure do
 
   describe ".ensure_registered_for_current_config!" do
     before do
-      stub_const("Sidekiq", Module.new)
+      stub_const("Sidekiq", fake_sidekiq)
       allow(Sidekiq).to receive(:configure_server).and_yield(double(
                                                                server_middleware: ->(&block) { block.call(double(add: nil, any?: false)) },
                                                                death_handlers: [],

--- a/spec/axn/core/early_completion_spec.rb
+++ b/spec/axn/core/early_completion_spec.rb
@@ -42,8 +42,12 @@ RSpec.describe Axn do
         # This will be tested with a mock transaction that tracks rollbacks
         rollback_called = false
 
-        # Mock ActiveRecord transaction behavior
-        stub_const("ActiveRecord::Base", Class.new)
+        # Mock ActiveRecord transaction behavior. Declaring the methods on the fake lets
+        # verify_partial_doubles confirm the stubbed methods exist.
+        stub_const("ActiveRecord::Base", Class.new do
+          def self.transaction; end
+          def self.rollback!; end
+        end)
         allow(ActiveRecord::Base).to receive(:transaction).and_yield
         allow(ActiveRecord::Base).to receive(:rollback!) { rollback_called = true }
 

--- a/spec/axn/core/testing/result_for_specs_spec.rb
+++ b/spec/axn/core/testing/result_for_specs_spec.rb
@@ -180,9 +180,9 @@ RSpec.describe "Action spec helpers" do
     describe "Axn::Result.ok" do
       context "when logging is enabled by default" do
         before do
-          allow_any_instance_of(Axn::Result).to receive(:info) do |_instance, message, **options|
-            log_messages << { level: :info, message:, options: }
-          end
+          # Logging routes through Axn.config.logger (see Axn::Core::Logging), so spy there —
+          # Axn::Result itself has no #info, which is why an any_instance stub on it was dead.
+          allow(Axn.config.logger).to receive(:info) { |message| log_messages << { level: :info, message: } }
         end
 
         it "does not log when using Result.ok" do
@@ -196,12 +196,9 @@ RSpec.describe "Action spec helpers" do
     describe "Axn::Result.error" do
       context "when logging is enabled by default" do
         before do
-          allow_any_instance_of(Axn::Result).to receive(:info) do |_instance, message, **options|
-            log_messages << { level: :info, message:, options: }
-          end
-          allow_any_instance_of(Axn::Result).to receive(:warn) do |_instance, message, **options|
-            log_messages << { level: :warn, message:, options: }
-          end
+          # See note above: spy on the real log sink, not on Axn::Result (which has no #info/#warn).
+          allow(Axn.config.logger).to receive(:info) { |message| log_messages << { level: :info, message: } }
+          allow(Axn.config.logger).to receive(:warn) { |message| log_messages << { level: :warn, message: } }
         end
 
         it "does not log when using Result.error" do

--- a/spec/axn/extras/strategies/vernier_spec.rb
+++ b/spec/axn/extras/strategies/vernier_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe Axn::Extras::Strategies::Vernier do
     Axn::Strategies.register(:vernier, described_class)
   end
 
+  # Vernier is lazily required (and not loaded in this suite), so we fake the constant.
+  # Declaring #profile lets verify_partial_doubles confirm the stubbed method really exists.
+  let(:fake_vernier) do
+    Module.new { def self.profile(*, **); end }
+  end
+
   let(:action_class) do
     build_axn do
       use :vernier
@@ -210,7 +216,7 @@ RSpec.describe Axn::Extras::Strategies::Vernier do
 
     context "when profiling should run" do
       before do
-        stub_const("Vernier", Module.new)
+        stub_const("Vernier", fake_vernier)
         allow(Vernier).to receive(:profile).and_yield
       end
 
@@ -246,7 +252,7 @@ RSpec.describe Axn::Extras::Strategies::Vernier do
 
   describe "integration with action execution" do
     before do
-      stub_const("Vernier", Module.new)
+      stub_const("Vernier", fake_vernier)
       allow(Vernier).to receive(:profile).and_yield
     end
 

--- a/spec/axn/internal/tracing/opentelemetry_spec.rb
+++ b/spec/axn/internal/tracing/opentelemetry_spec.rb
@@ -9,8 +9,9 @@ RSpec.describe "Axn::Internal::Tracing OpenTelemetry" do
     # Save original OpenTelemetry if it exists
     @original_otel = defined?(OpenTelemetry) ? OpenTelemetry : nil
 
-    # Create a simple OpenTelemetry module that we'll stub methods on
-    otel_module = Module.new
+    # Create a simple OpenTelemetry module that we'll stub methods on. Declaring the
+    # methods we stub lets verify_partial_doubles confirm they really exist on the fake.
+    otel_module = Module.new { def self.tracer_provider; end }
     trace_module = Module.new
     status_class = Class.new
     mock_status = instance_double("Status")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,12 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
+  config.mock_with :rspec do |mocks|
+    # Catch stubs/mocks on real objects (partial doubles) whose methods don't actually
+    # exist — prevents dead stubs from silently passing when an API is renamed/removed.
+    mocks.verify_partial_doubles = true
+  end
+
   config.before(:suite) do
     Axn.configure do |c|
       # Hide default logging

--- a/spec_rails/dummy_app/spec/spec_helper.rb
+++ b/spec_rails/dummy_app/spec/spec_helper.rb
@@ -28,6 +28,12 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
+  config.mock_with :rspec do |mocks|
+    # Catch stubs/mocks on real objects (partial doubles) whose methods don't actually
+    # exist — prevents dead stubs from silently passing when an API is renamed/removed.
+    mocks.verify_partial_doubles = true
+  end
+
   config.before(:suite) do
     Axn.configure do |c|
       # Hide default logging


### PR DESCRIPTION
## What

Enables RSpec's `verify_partial_doubles` in both the core (`spec/`) and Rails dummy-app (`spec_rails/`) suites. With it on, any stub/mock on a *real* object is checked against that object's actual API — so a stub on a renamed or nonexistent method errors instead of silently doing nothing.

This is the follow-up flagged while fixing PRO-2746: the original dead stub there (`base?` → `reason?`) survived precisely because this setting was off. Turning it on surfaced **37** such stubs across the suite, all fixed here.

Linear: https://linear.app/teamshares/issue/PRO-2789/axn-clean-test-suite-doubles

## The 37, by root cause

- **OpenTelemetry (16) / Sidekiq (5)** — neither lib is a dependency of the core suite, so the specs `stub_const` a bare `Module.new` and stub methods on it. The fake didn't declare those methods, so the partial double couldn't verify. Fix: declare the stubbed methods on the fake.
- **Vernier (8) / ActiveRecord::Base (1)** — real deps, but the specs still replaced them with a bare `Module`/`Class`. Same fix (declare the methods on the fake; Vernier is lazily required and not loaded in this suite, so the fake stays).
- **ActiveJob `perform_later` (4)** — `expect_any_instance_of(Class).to receive(:perform_later)` stubbed *every class object in the process* (`Class` has no `#perform_later`). Replaced with the proxy-double pattern already used by the sibling delayed-execution tests in the same file.
- **`result_for_specs` (3)** — a genuine dead stub: `allow_any_instance_of(Axn::Result).to receive(:info/:warn)`, but `Axn::Result` has no such methods — logging routes through `Axn.config.logger`. Now spies on the real log sink, which also makes the "does not log" assertions actually verify something.

Test-only change; no production code touched, so no CHANGELOG entry.