### PR TITLE
PRO-2804: Fix doc correctness issues found scanning against source

### DIFF
--- a/docs/advanced/mountable.md
+++ b/docs/advanced/mountable.md
@@ -15,7 +15,7 @@ This is in VERY EXPERIMENTAL use at Teamshares, but the API is still definitely 
 When you attach an action to a class, you get multiple ways to access it:
 
 1. **Direct method calls** on the class (e.g., `SomeClass.foo`), which depend on how you told it to mount
-3. **Namespace method calls** (e.g., `SomeClass::Axns.foo`) which always call the underlying axn directly (i.e. returning Axn::Result like a normal SomeAxn.call)
+2. **Namespace method calls** (e.g., `SomeClass::Axns.foo`) which always call the underlying axn directly (i.e. returning Axn::Result like a normal SomeAxn.call)
 
 ## Host Types
 
@@ -391,7 +391,6 @@ Method names must be convertible to valid Ruby constant names:
 # ✅ Valid names
 mount_axn(:create_user)           # Creates CreateUser constant
 mount_axn(:process_payment)       # Creates ProcessPayment constant
-mount_axn(:send-email)            # Creates SendEmail constant (parameterized)
 mount_axn(:step_1)                # Creates Step1 constant
 
 # ❌ Invalid names
@@ -401,13 +400,14 @@ mount_axn(:123invalid)            # Cannot start with number
 
 ### Special Character Handling
 
-The system automatically handles special characters using `parameterize`:
+The system automatically handles special characters using `parameterize`. Pass such names as strings (they are not valid symbol literals):
 
 ```ruby
-mount_axn(:send-email)     # Becomes SendEmail constant
-mount_axn(:step 1)         # Becomes Step1 constant
-mount_axn(:user@domain)    # Becomes UserDomain constant
+mount_axn("step 1")         # Becomes Step1 constant
+mount_axn("user@domain")    # Becomes UserDomain constant
 ```
+
+Note that hyphens do not round-trip cleanly: `"send-email"` parameterizes to `"Send-email"`, which is not a valid constant name and will raise. Use underscores (`"send_email"`) instead.
 
 ## Best Practices
 
@@ -497,9 +497,7 @@ class OrderWorkflow
     expose :confirmation_number, "CONF-123"
   end
 
-  def call
-    # Steps execute automatically
-  end
+  # The steps run automatically — no `def call` needed (defining one would override them).
 end
 ```
 

--- a/docs/advanced/profiling.md
+++ b/docs/advanced/profiling.md
@@ -19,7 +19,7 @@ Add the Vernier gem to your Gemfile:
 
 ```ruby
 # Gemfile
-gem 'vernier', '~> 0.1'
+gem 'vernier', '~> 1.0'
 ```
 
 Then run:
@@ -92,7 +92,8 @@ class DataProcessing
   # Profile using a method
   use :vernier, if: :should_profile? # [!code focus]
 
-  expects :records, :record_count, :debug_mode, type: :boolean, default: false
+  expects :records, :record_count
+  expects :debug_mode, type: :boolean, default: false
 
   def should_profile?
     record_count > 1000 || debug_mode
@@ -163,7 +164,8 @@ class ComplexAction
   # Profile when debug mode is enabled OR when processing admin users
   use :vernier, if: -> { debug_mode || user.admin? } # [!code focus]
 
-  expects :user, :debug_mode, type: :boolean, default: false
+  expects :user
+  expects :debug_mode, type: :boolean, default: false
 
   def call
     # Complex logic
@@ -293,7 +295,11 @@ end
 If you see this error:
 
 ```
-LoadError: Vernier gem is not loaded. Add `gem 'vernier', '~> 0.1'` to your Gemfile to enable profiling.
+LoadError: Vernier profiler is not available. To use profiling, add 'vernier' to your Gemfile:
+
+  gem 'vernier', '~> 1.0'
+
+Then run: bundle install
 ```
 
 Make sure to:

--- a/docs/intro/about.md
+++ b/docs/intro/about.md
@@ -36,7 +36,7 @@ The core library provides many benefits for individual action calls, but also ai
 * Linear flow
   * A list of actions to execute in series
   * Each layer `expects` and `exposes` its own accessor set, but internally all the values are passed down the chain (i.e. actor C can accept something A exposed that B didn’t touch and knows nothing about).
-  * The top-level action must `expose` it’s own layer (effectively documenting public vs private exposures, which drastically eases refactoring)
+  * The top-level action must `expose` its own layer (effectively documenting public vs private exposures, which drastically eases refactoring)
 * Ad hoc (called arbitrarily from within other actions)
   * Use `call!` to ensure any failure from a nested service raises an exception, or manually check `result.ok?` and handle failures appropriately
   * Declare a base `error` to give a parent's failures a consistent headline that prefixes nested failures, or run children with `call` + `fail!` for per-call-site context

--- a/docs/reference/async.md
+++ b/docs/reference/async.md
@@ -40,7 +40,7 @@ The Sidekiq adapter provides integration with the Sidekiq background job process
 ```ruby
 # In your action class
 async :sidekiq do
-  sidekiq_options queue: "high_priority", retry: 5, priority: 10
+  sidekiq_options queue: "high_priority", retry: 5
 end
 
 # Or with keyword arguments (shorthand)
@@ -50,7 +50,6 @@ async :sidekiq, queue: "high_priority", retry: 5
 **Configuration options:**
 - `queue`: The Sidekiq queue name (default: "default")
 - `retry`: Number of retry attempts (default: 25)
-- `priority`: Job priority (default: 0)
 - Any other Sidekiq options supported by `sidekiq_options`
 
 For detailed setup instructions including middleware configuration, see [Sidekiq Adapter Setup](/reference/async/sidekiq).
@@ -64,7 +63,6 @@ The ActiveJob adapter provides integration with Rails' ActiveJob framework.
 async :active_job do
   queue_as "high_priority"
   self.priority = 10
-  self.wait = 5.minutes
 end
 ```
 
@@ -224,8 +222,8 @@ SyncForCompany.enqueue_all  # Automatically iterates Company.all and enqueues ea
 
 **How it works:**
 1. `enqueue_all` validates configuration upfront (async configured, static args present)
-2. If all arguments are serializable, enqueues an `EnqueueAllOrchestrator` job in the background
-3. If any argument is unserializable (e.g., an AR relation override), executes in the foreground instead
+2. By default, enqueues an `EnqueueAllOrchestrator` job that performs the iteration in the background
+3. If an iterable is passed as a keyword argument (e.g., overriding the source with an AR relation), that source can't be serialized for a background job, so the iteration runs in the foreground instead
 4. During execution, iterates over the source collection and enqueues individual jobs
 5. Model-based iterations (using `find_each`) are processed first for memory efficiency
 

--- a/docs/reference/axn-result.md
+++ b/docs/reference/axn-result.md
@@ -11,7 +11,7 @@ Every `call` invocation on an Axn will return an `Axn::Result` instance, which p
 | `exception` | If not `ok?` because an exception was swallowed, will be set to the swallowed exception (note: rarely used outside development; prefer to let the library automatically handle exception handling for you)
 | `outcome` | The execution outcome as a string inquirer (`success?`, `failure?`, `exception?`)
 | `elapsed_time` | Execution time in milliseconds (Float)
-| `finalized?` | `true` if the result has completed execution (either successfully or with an exception), `false` if still in progress
+| `finalized?` | `true` if the result has completed execution (success, failure, or exception), `false` if still in progress
 | any `expose`d values | guaranteed to be set if `ok?`; fields that are also `expects`-declared are auto-copied and available on `fail!` and exception paths too (see [Re-exposing an expected field](/usage/writing#re-exposing-an-expected-field-auto-copy))
 
 NOTE: `success` and `error` (and so implicitly `message`) can be configured per-action via [the `success` and `error` declarations](/reference/class#success-and-error).

--- a/docs/reference/class.md
+++ b/docs/reference/class.md
@@ -557,6 +557,8 @@ This is triggered after the Axn completes successfully, once the enclosing datab
 
 Triggered on ANY error (explicit `fail!` or uncaught exception). Optional filter argument works the same as `on_exception` (documented below).
 
+`on_error` is a superset of `on_failure` and `on_exception`, so it co-fires with whichever specific bucket applies: a `fail!` triggers both `on_error` and `on_failure`, and an uncaught exception triggers both `on_error` and `on_exception`. If you register `on_error` alongside the specific callback, expect both to run — they are not mutually exclusive.
+
 ### `on_failure`
 
 Triggered ONLY on explicit `fail!` (i.e. _not_ by an uncaught exception). Optional filter argument works the same as `on_exception` (documented below).

--- a/docs/reference/instance.md
+++ b/docs/reference/instance.md
@@ -33,7 +33,7 @@ Helper method to log (via the [configurable](/reference/configuration#logger) `A
 * First argument (required) is a string message to log
 * Also accepts a `level:` keyword argument to change the log level (defaults to `info`)
 
-Primarily used for its side effects; returns whatever the underlying `Axn.config.logger` instance returns but it does return a Hash with the key/value pair(s) you exposed.
+Primarily used for its side effects; returns whatever the underlying `Axn.config.logger` instance returns.
 
 
 

--- a/docs/strategies/client.md
+++ b/docs/strategies/client.md
@@ -29,8 +29,8 @@ end
 | Option | Default | Description |
 | ------ | ------- | ----------- |
 | `name` | `:client` | The method name for accessing the client |
-| `url` | (required) | Base URL for the API |
-| `headers` | `{}` | Default headers to include in all requests |
+| `url` | (none) | Base URL for the API. Not enforced by the strategy — it's passed through to `Faraday.new`, so it's effectively required only if you make relative requests. |
+| `headers` | `{}` | Default headers to include in all requests (passed through to `Faraday.new`) |
 | `user_agent` | Auto-generated | Custom User-Agent header |
 | `debug` | `false` | Enable Faraday response logging |
 | `prepend_config` | `nil` | Proc to prepend middleware configuration |
@@ -40,14 +40,21 @@ Any additional options are passed directly to `Faraday.new`.
 
 ## Default Middleware
 
-The client strategy automatically configures these middleware:
+The client strategy sets these headers and middleware on the Faraday connection.
 
-1. `Content-Type: application/json` header
-2. `User-Agent` header (configurable)
-3. `response :raise_error` - Raises on 4xx/5xx responses
-4. `request :url_encoded` - Encodes request parameters
-5. `request :json` - JSON request encoding
-6. `response :json` - JSON response parsing
+**Headers:**
+
+- `Content-Type: application/json`
+- `User-Agent` (configurable via `user_agent:`)
+
+**Middleware** (registered in this order; any `prepend_config` proc runs before them):
+
+1. An execution-context middleware that records the last request/response so it can be attached to exception reports
+2. `response :raise_error` - Raises on 4xx/5xx responses
+3. `request :url_encoded` - Encodes request parameters
+4. `request :json` - JSON request encoding
+5. `response :json` - JSON response parsing (only for `json` content types)
+6. `response :logger` - Response logging, only when `debug: true`
 
 ## Custom Client Name
 

--- a/docs/strategies/form.md
+++ b/docs/strategies/form.md
@@ -12,18 +12,16 @@ Use the form strategy when you need to validate **user-facing input** with user-
 class CreateUser
   include Axn
 
-  use :form, type: CreateUser::Form
+  use :form do
+    validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+    validates :name, presence: true, length: { minimum: 2 }
+  end
 
   def call
     # form is automatically validated and exposed
     # If validation fails, the action fails with form.errors
     User.create!(form.to_h)
   end
-end
-
-class CreateUser::Form < Axn::FormObject
-  validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
-  validates :name, presence: true, length: { minimum: 2 }
 end
 ```
 
@@ -50,7 +48,9 @@ The `type` option determines which form class to use:
 # Explicit type
 use :form, type: RegistrationForm
 
-# String constant (useful for avoiding load order issues)
+# String constant — defers the bareword reference so it plays nicely with Rails
+# autoloading. The constant must still be loadable when `use :form` runs; for full
+# load-order independence (defining the form inline), pass a block instead.
 use :form, type: "Users::RegistrationForm"
 
 # Auto-detected from action name
@@ -118,7 +118,9 @@ class UpdateProfile
   use :form, type: ProfileForm, inject: [:user] # [!code focus]
 
   def call
-    user.update!(form.to_h)
+    # Injected fields are real accessors, so they show up in `form.to_h`.
+    # Exclude them when passing attributes to a writer like `update!`.
+    user.update!(form.to_h.except(:user)) # [!code focus]
   end
 end
 
@@ -202,23 +204,6 @@ end
 ## Complete Example
 
 ```ruby
-class CreateCompanyMember
-  include Axn
-
-  expects :company, model: Company
-  use :form, type: MemberForm, inject: [:company]
-
-  exposes :member
-
-  error { form.errors.full_messages.to_sentence }
-  success { "#{member.name} has been added to #{company.name}" }
-
-  def call
-    member = company.members.create!(form.to_h)
-    expose member: member
-  end
-end
-
 class MemberForm < Axn::FormObject
   attr_accessor :company  # Injected
 
@@ -234,6 +219,23 @@ class MemberForm < Axn::FormObject
     return unless company&.members&.exists?(email: email)
 
     errors.add(:email, "is already a member of this company")
+  end
+end
+
+class CreateCompanyMember
+  include Axn
+
+  expects :company, model: Company
+  use :form, type: MemberForm, inject: [:company]
+
+  exposes :member
+
+  error { form.errors.full_messages.to_sentence }
+  success { "#{member.name} has been added to #{company.name}" }
+
+  def call
+    member = company.members.create!(form.to_h)
+    expose member: member
   end
 end
 ```

--- a/docs/usage/steps.md
+++ b/docs/usage/steps.md
@@ -187,15 +187,15 @@ step :validation, expects: [:input] do
   fail! "Input too short"
 end
 
-# If this step fails, the error message becomes: "validation step: Input too short"
+# If this step fails, the error message becomes: "validation: Input too short"
 ```
 
 ### Step Failure Propagation
 
 When a step fails:
-1. The step's exception is caught
+1. The step's failure or exception is caught
 2. The parent action fails with the prefixed error message
-3. The `on_exception` handlers are triggered appropriately
+3. The matching callbacks fire: a step that calls `fail!` settles as a failure (`on_failure`), while a step that raises an unhandled exception settles as an exception (`on_exception`). `on_error` fires in both cases.
 
 ### Exception Handling
 
@@ -206,7 +206,7 @@ step :risky_operation, expects: [:input] do
   raise StandardError, "Something went wrong with #{input}"
 end
 
-# The exception is caught and the error message becomes: "risky_operation step: Something went wrong with [input]"
+# The exception is caught and the error message becomes: "risky_operation: Something went wrong with [input]"
 ```
 
 

--- a/docs/usage/writing.md
+++ b/docs/usage/writing.md
@@ -223,7 +223,7 @@ Would give us these outputs:
 ```ruby
 Foo.call.error # => "No secret of life for you: Name can't be blank"
 Foo.call(name: "Doug").error # => "Douglas already knows the meaning"
-Foo.call(name: "Adams").success # => "Revealed the secret of life to Adams"
+Foo.call(name: "Adams").success # => "Revealed to Adams: Hello Adams, the meaning of life is 42"
 Foo.call(name: "Adams").meaning_of_life # => "Hello Adams, the meaning of life is 42"
 ```
 


### PR DESCRIPTION
## Summary

Scanned all 27 doc pages against the actual `lib/` implementation (fanned out across parallel reviewers, each finding re-verified against source or by running it) and fixed the confirmed inaccuracies. These are all cases where the docs described behavior the code doesn't have, showed examples that error, or stated fabricated defaults.

Linear: https://linear.app/teamshares/issue/PRO-2804

## Correctness fixes

| File | Issue | Fix |
|---|---|---|
| `usage/steps.md` | Error prefix shown as `"validation step: …"` | Real prefix is `"validation: …"` (`step.rb:52`) |
| `usage/steps.md` | "Step failure → `on_exception`" blanket claim | `fail!`→`on_failure`, raise→`on_exception`, `on_error` for both |
| `usage/writing.md` | `.success` output comment didn't match the `success` block | Corrected to the actual string |
| `reference/instance.md` | `#log` "returns a Hash with the values you exposed" | Removed — returns the logger's return value |
| `reference/axn-result.md` | `finalized?` described only success/exception | Now success, failure, or exception |
| `reference/async.md` | `self.wait = 5.minutes` raises `NoMethodError` (confirmed) | Removed (`self.priority` kept — verified valid) |
| `reference/async.md` | Sidekiq `priority` option "(default: 0)" — fabricated | Removed from example + table |
| `reference/async.md` | `enqueue_all` foreground trigger described as "any unserializable arg" | Corrected to the real condition: an iterable passed as a kwarg |
| `advanced/profiling.md` | `gem 'vernier', '~> 0.1'` (×2) | `~> 1.0` (`vernier.rb:91`) |
| `advanced/profiling.md` | Fabricated `LoadError` text | Replaced with the real message |
| `advanced/profiling.md` | Shared `expects` kwargs applied boolean+default to all fields (×2) | Split into separate `expects` lines |
| `advanced/mountable.md` | Empty `def call` silently overrides the generated step `call` | Replaced with a clarifying comment |
| `advanced/mountable.md` | `mount_axn(:send-email)` → `SendEmail` — actually yields invalid `"Send-email"` (confirmed) | Dropped; added a note on hyphens |
| `advanced/mountable.md` | Overview list numbered 1→3 | Renumbered |
| `strategies/form.md` | Basic Usage + Complete Example reference the form class before defining it → `NameError` at load (`use` resolves eagerly) | Block form / define-first |
| `strategies/form.md` | "String constant avoids load-order issues" — misleading | Clarified Rails-autoload nuance |
| `strategies/form.md` | `inject`ed fields silently appear in `form.to_h` | Example now `except`s them, with a note |
| `strategies/client.md` | `url` marked "(required)" — actually a Faraday passthrough | Clarified |
| `strategies/client.md` | "Default Middleware" list conflated headers with middleware and omitted the auto-injected execution-context middleware | Rewrote accurately |
| `reference/class.md` | — | Note that `on_error` co-fires with `on_failure`/`on_exception` |
| `intro/about.md` | "it's own" | "its own" |

## Test plan

- `npm run docs:build` passes.
- Spot-check the rewritten `form.md` Basic Usage / Complete Example and `profiling.md` `expects` snippets render as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)