### PR TITLE
Docs: add "Wrapping External Service Clients" recipe

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -56,9 +56,9 @@ export default defineConfig({
         text: 'Recipes',
         items: [
           { text: 'Memoization', link: '/recipes/memoization' },
-          { text: 'Wrapping External Service Clients', link: '/recipes/wrapping-external-clients' },
           { text: 'Validating User Input', link: '/recipes/validating-user-input' },
           { text: 'Testing Actions', link: '/recipes/testing' },
+          { text: 'Wrapping External Service Clients', link: '/recipes/wrapping-external-clients' },
           { text: 'RuboCop Integration', link: '/recipes/rubocop-integration' },
           { text: 'Suppressing Duplicate Async Reports', link: '/recipes/suppressing-duplicate-async-reports' },
           { text: 'Configuration for Axn-based Gems', link: '/recipes/gem-configuration' },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -56,6 +56,7 @@ export default defineConfig({
         text: 'Recipes',
         items: [
           { text: 'Memoization', link: '/recipes/memoization' },
+          { text: 'Wrapping External Service Clients', link: '/recipes/wrapping-external-clients' },
           { text: 'Validating User Input', link: '/recipes/validating-user-input' },
           { text: 'Testing Actions', link: '/recipes/testing' },
           { text: 'RuboCop Integration', link: '/recipes/rubocop-integration' },

--- a/docs/recipes/wrapping-external-clients.md
+++ b/docs/recipes/wrapping-external-clients.md
@@ -1,0 +1,103 @@
+# Wrapping External Service Clients
+
+A convention several Axn-based apps have converged on: wrap each external service (a third-party API, a vendor SDK, an internal service) in a single class that `include`s `Axn`, memoizes the underlying connection, and mounts one action per operation via [`mount_axn_method`](/advanced/mountable#mount_axn_method-strategy).
+
+This is a **convention, not a framework requirement** — nothing in Axn enforces it. It's written up here because it has been consistently useful, and because the choice of `mount_axn_method` (rather than `mount_axn`) is deliberate in a way that's worth understanding before you copy the pattern.
+
+## The shape
+
+One class per service. Memoize the client/connection privately, then mount one operation per `mount_axn_method`:
+
+```ruby
+class Clients::AuthZero
+  include Axn
+
+  mount_axn_method :create_user,
+    expects: { password: { sensitive: true } },
+    error: ->(exception:) { HttpErrorMessage.user_message(exception, fallback: CREATE_USER_ERROR_FALLBACK) } do |name:, email:, password:|
+    auth0_client.create_user(CONNECTION_NAME, name:, email:, password:)
+  end
+
+  mount_axn_method :change_password, expects: { password: { sensitive: true } } do |user_id:, password:|
+    auth0_client.patch_user(user_id, password:)
+  end
+
+  private
+
+  memo def auth0_client # [!code focus]
+    Auth0Client.new(client_id: ENV["..."], client_secret: ENV["..."], domain: ENV["..."])
+  end
+end
+```
+
+Each block returns a single value (the API response), so `mount_axn_method` auto-exposes it as `value`. Shared concerns — credentials, the memoized client, error-message constants — live on the wrapper, out of the individual operations.
+
+## Why `mount_axn_method`, not `mount_axn`
+
+This is the load-bearing decision. `mount_axn_method` gives you a single bang method that **raises on failure and returns the exposed value directly**:
+
+```ruby
+# Returns the user array directly; raises if the call fails.
+user = Clients::AuthZero.find_user_by_email!(email:).first
+```
+
+That's the ergonomic common case. But the full [`Result` interface](/reference/axn-result) is *also* available — mounting always generates an `Axns` namespace alongside the convenience method:
+
+```ruby
+# Returns a Result; branch on ok? instead of rescuing.
+result = Clients::AuthZero::Axns.change_password(user_id:, password:)
+if result.ok?
+  redirect_to settings_path, success: "Password updated."
+else
+  flash[:error] = result.error
+end
+```
+
+So one `mount_axn_method` gives you **both** interfaces, and the *caller* picks per call site:
+
+- `Service.op!(...)` — when you want the value and a failure should raise.
+- `Service::Axns.op(...)` — when you want to handle failure gracefully (e.g. a controller rendering an error).
+
+Switching the mount to `mount_axn` would put the non-bang `Result` method directly on the wrapper (`Service.op(...)`), saving the `::Axns` segment — but at the cost of the auto-value-return: `op!` would then hand back a `Result` instead of the value, so every `Service.op!(...)` site would need a trailing `.value`. Since the value-return case is overwhelmingly the common one, that's a net loss. Reach into `::Axns` for the occasional `Result`; keep the convenience method for everything else.
+
+## Map vendor errors at the boundary
+
+The wrapper is the right place to translate vendor-specific exceptions into user-facing `result.error` strings, so callers never have to know the shape of the underlying API's errors. Use a per-operation `error:` handler, or — when a whole service shares error semantics — declare them once on a base class keyed by exception class:
+
+```ruby
+error "Please sign in again.", if: TeamsharesAPI::AuthorizationError # [!code focus]
+error "That item wasn't found.", if: TeamsharesAPI::NotFoundError # [!code focus]
+error "Something went wrong. Please try again.", if: TeamsharesAPI::ServerError # [!code focus]
+```
+
+These resolve only for the non-bang (`Result`) path — the bang method still raises the original exception — which pairs naturally with the two-interface split above.
+
+## Services with many endpoints: share a base
+
+When a service has several resources, give it a `Base` that holds the connection (often via the [`:client` strategy](/strategies/client)) and shared helpers, then keep each resource thin:
+
+```ruby
+class Clients::Zendesk::Base
+  include Axn
+
+  use :client, name: :zendesk, url: "https://teamshares.zendesk.com/api/v2", headers: { ... }
+end
+
+class Clients::Zendesk::User < Clients::Zendesk::Base
+  mount_axn_method :get do |id:|
+    zendesk.get("users/#{id}").body["user"]
+  end
+end
+```
+
+Subclasses inherit the connection and any shared private helpers; they only declare their own operations.
+
+## When the pattern doesn't fit
+
+`mount_axn_method` requires each operation to expose **exactly one** value (it auto-unwraps that single field). If an operation genuinely needs to expose multiple named fields, it can't use `mount_axn_method` — switch that operation to [`mount_axn`](/advanced/mountable#axn-strategy) (which returns the full `Result` from `op`/`op!` and exposes all fields), or have it return a single composite object. In practice external-service operations almost always map to one return value, so this is rare.
+
+## See also
+
+- [Mountable Actions](/advanced/mountable) — the `mount_axn_method` and `mount_axn` primitives this pattern builds on.
+- [Client Strategy](/strategies/client) — the `use :client` HTTP connection helper used by the base-class flavor above.
+- [Result Interface](/reference/axn-result) — what `Service::Axns.op(...)` hands back.

--- a/docs/recipes/wrapping-external-clients.md
+++ b/docs/recipes/wrapping-external-clients.md
@@ -65,9 +65,9 @@ Switching the mount to `mount_axn` would put the non-bang `Result` method direct
 The wrapper is the right place to translate vendor-specific exceptions into user-facing `result.error` strings, so callers never have to know the shape of the underlying API's errors. Use a per-operation `error:` handler, or — when a whole service shares error semantics — declare them once on a base class keyed by exception class:
 
 ```ruby
-error "Please sign in again.", if: PaymentProvider::AuthenticationError # [!code focus]
-error "That charge wasn't found.", if: PaymentProvider::NotFoundError # [!code focus]
-error "Payment failed. Please try again.", if: PaymentProvider::Error # [!code focus]
+error "Please sign in again.", if: PaymentProvider::AuthenticationError
+error "That charge wasn't found.", if: PaymentProvider::NotFoundError
+error "Payment failed. Please try again.", if: PaymentProvider::Error
 ```
 
 These resolve only for the non-bang (`Result`) path — the bang method still raises the original exception — which pairs naturally with the two-interface split above.

--- a/docs/recipes/wrapping-external-clients.md
+++ b/docs/recipes/wrapping-external-clients.md
@@ -9,23 +9,23 @@ This is a **convention, not a framework requirement** — nothing in Axn enforce
 One class per service. Memoize the client/connection privately, then mount one operation per `mount_axn_method`:
 
 ```ruby
-class Clients::AuthZero
+class Clients::Payments
   include Axn
 
-  mount_axn_method :create_user,
-    expects: { password: { sensitive: true } },
-    error: ->(exception:) { HttpErrorMessage.user_message(exception, fallback: CREATE_USER_ERROR_FALLBACK) } do |name:, email:, password:|
-    auth0_client.create_user(CONNECTION_NAME, name:, email:, password:)
+  mount_axn_method :create_charge,
+    expects: { card_token: { sensitive: true } },
+    error: ->(exception:) { PaymentErrorMessage.user_message(exception, fallback: CHARGE_ERROR_FALLBACK) } do |amount_cents:, card_token:|
+    payment_client.charge(amount_cents:, source: card_token)
   end
 
-  mount_axn_method :change_password, expects: { password: { sensitive: true } } do |user_id:, password:|
-    auth0_client.patch_user(user_id, password:)
+  mount_axn_method :refund, expects: { charge_id: { type: String } } do |charge_id:|
+    payment_client.refund(charge_id)
   end
 
   private
 
-  memo def auth0_client # [!code focus]
-    Auth0Client.new(client_id: ENV["..."], client_secret: ENV["..."], domain: ENV["..."])
+  memo def payment_client # [!code focus]
+    PaymentProvider::Client.new(api_key: ENV["PAYMENT_PROVIDER_API_KEY"])
   end
 end
 ```
@@ -37,17 +37,17 @@ Each block returns a single value (the API response), so `mount_axn_method` auto
 This is the load-bearing decision. `mount_axn_method` gives you a single bang method that **raises on failure and returns the exposed value directly**:
 
 ```ruby
-# Returns the user array directly; raises if the call fails.
-user = Clients::AuthZero.find_user_by_email!(email:).first
+# Returns the charge object directly; raises if the call fails.
+charge = Clients::Payments.create_charge!(amount_cents:, card_token:)
 ```
 
 That's the ergonomic common case. But the full [`Result` interface](/reference/axn-result) is *also* available — mounting always generates an `Axns` namespace alongside the convenience method:
 
 ```ruby
 # Returns a Result; branch on ok? instead of rescuing.
-result = Clients::AuthZero::Axns.change_password(user_id:, password:)
+result = Clients::Payments::Axns.refund(charge_id:)
 if result.ok?
-  redirect_to settings_path, success: "Password updated."
+  redirect_to receipt_path, success: "Refund issued."
 else
   flash[:error] = result.error
 end
@@ -65,9 +65,9 @@ Switching the mount to `mount_axn` would put the non-bang `Result` method direct
 The wrapper is the right place to translate vendor-specific exceptions into user-facing `result.error` strings, so callers never have to know the shape of the underlying API's errors. Use a per-operation `error:` handler, or — when a whole service shares error semantics — declare them once on a base class keyed by exception class:
 
 ```ruby
-error "Please sign in again.", if: TeamsharesAPI::AuthorizationError # [!code focus]
-error "That item wasn't found.", if: TeamsharesAPI::NotFoundError # [!code focus]
-error "Something went wrong. Please try again.", if: TeamsharesAPI::ServerError # [!code focus]
+error "Please sign in again.", if: PaymentProvider::AuthenticationError # [!code focus]
+error "That charge wasn't found.", if: PaymentProvider::NotFoundError # [!code focus]
+error "Payment failed. Please try again.", if: PaymentProvider::Error # [!code focus]
 ```
 
 These resolve only for the non-bang (`Result`) path — the bang method still raises the original exception — which pairs naturally with the two-interface split above.
@@ -77,15 +77,15 @@ These resolve only for the non-bang (`Result`) path — the bang method still ra
 When a service has several resources, give it a `Base` that holds the connection (often via the [`:client` strategy](/strategies/client)) and shared helpers, then keep each resource thin:
 
 ```ruby
-class Clients::Zendesk::Base
+class Clients::Crm::Base
   include Axn
 
-  use :client, name: :zendesk, url: "https://teamshares.zendesk.com/api/v2", headers: { ... }
+  use :client, name: :crm, url: "https://api.example.com/v2", headers: { ... }
 end
 
-class Clients::Zendesk::User < Clients::Zendesk::Base
+class Clients::Crm::Contact < Clients::Crm::Base
   mount_axn_method :get do |id:|
-    zendesk.get("users/#{id}").body["user"]
+    crm.get("contacts/#{id}").body["contact"]
   end
 end
 ```

--- a/docs/recipes/wrapping-external-clients.md
+++ b/docs/recipes/wrapping-external-clients.md
@@ -65,10 +65,12 @@ Switching the mount to `mount_axn` would put the non-bang `Result` method direct
 The wrapper is the right place to translate vendor-specific exceptions into user-facing `result.error` strings, so callers never have to know the shape of the underlying API's errors. Use a per-operation `error:` handler, or — when a whole service shares error semantics — declare them once on a base class keyed by exception class:
 
 ```ruby
-error "Please sign in again.", if: PaymentProvider::AuthenticationError
-error "That charge wasn't found.", if: PaymentProvider::NotFoundError
 error "Payment failed. Please try again.", if: PaymentProvider::Error
+error "That charge wasn't found.", if: PaymentProvider::NotFoundError
+error "Please sign in again.", if: PaymentProvider::AuthenticationError
 ```
+
+Order matters: the **last** matching `error` wins. When the vendor's exceptions form a hierarchy (e.g. `AuthenticationError < PaymentProvider::Error`), declare the broad catch-all first and the more-specific classes last, so a specific match isn't shadowed by the catch-all.
 
 These resolve only for the non-bang (`Result`) path — the bang method still raises the original exception — which pairs naturally with the two-interface split above.
 


### PR DESCRIPTION
## What

Adds a new recipe, **Wrapping External Service Clients**, documenting the convention several Axn-based apps have converged on: wrap each external service in a class that `include`s `Axn`, memoizes the underlying connection, and mounts one operation per `mount_axn_method`.

The recipe's core point is *why* `mount_axn_method` (rather than `mount_axn`) is the deliberate choice: one mount gives you **both** interfaces — the auto-value-return bang method (`Service.op!` → value, raises) for the common case, and the full `Result` via the `Service::Axns.op` namespace for graceful error handling. Swapping to `mount_axn` would drop the auto-value-return and force a trailing `.value` on every convenience call.

Also covers: mapping vendor errors to user-facing messages at the boundary, sharing a `Base` for multi-endpoint services, and when an operation should fall back to `mount_axn` (multiple exposed fields).

This came out of an investigation into whether existing `Clients::*` wrappers (and `TeamsharesAPI`) should switch to `mount_axn` — conclusion was no, and that the valuable output was documenting the convention and its rationale.

## Changes

- `docs/recipes/wrapping-external-clients.md` — new recipe
- `docs/.vitepress/config.mjs` — sidebar entry under Recipes