### PR TITLE
PRO-2816: Fiber-safety readiness for async support

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -68,6 +68,7 @@ export default defineConfig({
         text: 'Advanced',
         items: [
           { text: 'Profiling', link: '/advanced/profiling' },
+          { text: 'Concurrency & Fiber Safety', link: '/advanced/concurrency' },
           { text: 'Conventions', link: '/advanced/conventions' },
           { text: 'Mountable', link: '/advanced/mountable' },
           { text: 'Internal Notes', link: '/advanced/rough' },

--- a/docs/advanced/concurrency.md
+++ b/docs/advanced/concurrency.md
@@ -1,0 +1,83 @@
+# Concurrency & Fiber Safety
+
+Axn is safe to run concurrently. This page explains how, and the one knob you need to set if you run actions under a **fiber-based** server or job processor (e.g. [async](https://github.com/socketry/async) / [Falcon](https://github.com/socketry/falcon)).
+
+## TL;DR
+
+- **Thread-based concurrency** (Sidekiq, Puma threads, ActiveJob on a threaded backend): safe out of the box. Nothing to configure.
+- **Fiber-based concurrency** (async / Falcon): set `isolation_level = :fiber` in your host app. Axn will emit a warning at runtime if it detects a fiber scheduler while this is still set to the default `:thread`.
+
+## How Axn scopes per-execution state
+
+Almost all of Axn's state is held in instance variables on objects created fresh for each `call` (the context, the result, memoized readers). That state is never shared between executions, so it is inherently isolated regardless of threads or fibers.
+
+The small amount of state that is *ambient* to a call tree — the nesting stack, the exception report-dedup and `fails_on` classification sets, and the current async retry context — is stored in [`ActiveSupport::IsolatedExecutionState`](https://api.rubyonrails.org/classes/ActiveSupport/IsolatedExecutionState.html). Axn deliberately uses this rather than raw thread-locals, because it is the same mechanism ActiveRecord and `CurrentAttributes` ride: its scoping follows a single host-app setting, `isolation_level`.
+
+## The `isolation_level` knob
+
+`ActiveSupport::IsolatedExecutionState.isolation_level` is either `:thread` (the default) or `:fiber`, and it decides what "current execution" means for *all* of the above:
+
+- Under `:thread`, state is keyed to `Thread.current`. Each thread gets its own state, so thread-based concurrency is isolated — but **multiple fibers on one thread share it**.
+- Under `:fiber`, state is keyed to `Fiber.current`. Each fiber (and therefore each thread, since every thread has its own root fiber) gets its own state, so **both** thread- and fiber-based concurrency are isolated.
+
+This is why a fiber host needs `:fiber`: under the default `:thread`, concurrent fibers would share — and corrupt — Axn's nesting stack and classification sets. In Rails:
+
+```ruby
+# config/application.rb — only needed for fiber-based servers/job processors
+config.active_support.isolation_level = :fiber
+```
+
+Outside Rails:
+
+```ruby
+ActiveSupport::IsolatedExecutionState.isolation_level = :fiber
+```
+
+In practice a Rails app on Falcon almost always sets this already, because ActiveRecord's per-execution connection lease depends on the very same setting — leave it `:thread` under fibers and connection pooling breaks before Axn ever would.
+
+### Why Axn doesn't set it for you
+
+`isolation_level` is an application-global that also governs ActiveRecord and `CurrentAttributes`, and assigning it at runtime calls `IsolatedExecutionState.clear` (wiping all existing state). A library flipping it would be both presumptuous and unsafe, so Axn inherits the host's choice and warns on a dangerous mismatch instead.
+
+### The runtime warning
+
+When Axn opens a call tree, if it detects an active `Fiber.scheduler` (the signal that fibers are in play) while `isolation_level` is still `:thread`, it logs a one-time warning pointing at the fix. Under plain threads (no scheduler) it stays silent.
+
+## Using async in an action
+
+Two different things get called "async" — keep them separate:
+
+**Background jobs (`call_async`).** Axn's `async :sidekiq` / `async :active_job` run the action later on a background-job worker. These are thread-based (one job per thread), so the default `:thread` isolation is correct and there is nothing to configure. This is the common path; see [Async Execution](/reference/async).
+
+**In-process fan-out with the [async](https://github.com/socketry/async) gem.** Axn has no fiber-based adapter, so you orchestrate this yourself by wrapping `.call` in `Async {}`:
+
+```ruby
+require "async"
+
+class FetchAllProfiles
+  include Axn
+  expects :user_ids
+
+  def call
+    profiles = Sync do
+      user_ids.map { |id| Async { FetchProfile.call!(id:).profile } }.map(&:wait)
+    end
+    expose :profiles, profiles
+  end
+end
+```
+
+This only behaves correctly when the host has `isolation_level = :fiber` — otherwise the concurrent fibers share the calling thread's execution state. Two things to keep in mind:
+
+- It is safe to set `:fiber` even under a thread-based server like Puma: each server thread has its own root fiber, so normal request handling stays isolated, and the fan-out fibers get their own state too.
+- Each `Async {}` task is its own call tree (the child-fiber caveat below), and it leases its own ActiveRecord connection — so size your pool for the concurrency, and don't rely on `CurrentAttributes`/ambient state set outside the task.
+
+## The invariant (for contributors)
+
+Axn keeps **no** per-execution state in raw thread-locals (`Thread.current[...]`, `thread_variable_*`), class variables (`@@foo`), or globals. Those patterns leak across fibers no matter how `isolation_level` is set, so they are banned — a spec (`spec/axn/no_unscoped_execution_state_spec.rb`) fails the build if any appear in `lib/`. If you need ambient per-execution state, use `ActiveSupport::IsolatedExecutionState[...]` so it inherits the host's scoping like everything else.
+
+## Notes & sharp edges
+
+**Lazy-initialized singletons.** A few process-global config objects (`Axn.config`, the extension config) memoize on first use. The computation is idempotent, so a concurrent first-touch is harmless — but if you want to avoid even redundant work on a hot path, touch them once at boot (e.g. reference `Axn.config` in an initializer) so initialization never races.
+
+**Child fibers don't inherit the parent's call tree.** `IsolatedExecutionState` is keyed by fiber *identity*, not inherited into child fibers. So if you fan out sub-actions across child fibers *inside* an action (`Async { SubAction.call }`), each child starts a fresh call tree — nested-report dedup and `fails_on` stickiness won't span that boundary. For genuinely concurrent sub-actions this is usually the behavior you want, but it's worth knowing.

--- a/lib/axn/core/nesting_tracking.rb
+++ b/lib/axn/core/nesting_tracking.rb
@@ -14,7 +14,10 @@ module Axn
         # a prior run might have left behind without draining the stack (e.g. an executor invoked
         # outside this wrapper, or an aborted teardown). Defends against a stale "already reported"
         # mark on a reused thread/fiber silently suppressing a real report.
-        Axn::Internal::ExceptionClassification.reset! if _current_axn_stack.empty?
+        if _current_axn_stack.empty?
+          Axn::Internal::ExceptionClassification.reset!
+          _warn_if_fiber_isolation_mismatch
+        end
         _current_axn_stack.push(axn)
         yield
       ensure
@@ -23,6 +26,26 @@ module Axn
         # object re-raised by a later, independent run starts fresh (report dedup + fails_on
         # stickiness are scoped to one call tree).
         Axn::Internal::ExceptionClassification.reset! if _current_axn_stack.empty?
+      end
+
+      # axn's per-execution state lives in ActiveSupport::IsolatedExecutionState, which is scoped by
+      # `isolation_level`. A fiber-based host (async/Falcon) running under the default :thread isolation
+      # would share that state across concurrent fibers on one thread — silently corrupting the nesting
+      # stack and exception-classification sets. We can't safely fix it for them (assigning
+      # isolation_level= at runtime calls IsolatedExecutionState.clear, nuking AR/CurrentAttributes), so
+      # we warn once and point at the fix. A scheduler being installed is the intent-to-run-fibers signal.
+      def self._warn_if_fiber_isolation_mismatch
+        return if @_isolation_mismatch_warned
+        return unless Fiber.respond_to?(:scheduler) && Fiber.scheduler
+        return unless ActiveSupport::IsolatedExecutionState.isolation_level == :thread
+
+        @_isolation_mismatch_warned = true
+        Axn.config.logger.warn(
+          "[Axn] A Fiber scheduler is active but ActiveSupport::IsolatedExecutionState.isolation_level " \
+          "is :thread. axn's per-execution state will leak across concurrent fibers. Set " \
+          "`config.active_support.isolation_level = :fiber` (Rails) or " \
+          "`ActiveSupport::IsolatedExecutionState.isolation_level = :fiber` to isolate it correctly.",
+        )
       end
     end
   end

--- a/spec/axn/core/fiber_isolation_spec.rb
+++ b/spec/axn/core/fiber_isolation_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# Regression guard for axn's fiber-safety contract.
+#
+# All of axn's per-execution shared state (nesting stack, exception-classification sets, async retry
+# context) lives in ActiveSupport::IsolatedExecutionState, which is scoped by `isolation_level`. These
+# tests pin the two halves of the contract:
+#   * under :fiber, that state isolates across concurrent fibers on one thread (the safe config), and
+#   * under :thread (the default), it is SHARED across fibers — the silent-corruption mode that the
+#     mismatch warning (see fiber_isolation_warning_spec) exists to surface.
+#
+# We interleave raw Fibers manually (no async-gem dependency): resume fiber A so it suspends mid-call
+# with state set, then run fiber B and observe whether it sees A's state.
+RSpec.describe "Fiber isolation contract" do
+  def with_isolation_level(level)
+    previous = ActiveSupport::IsolatedExecutionState.isolation_level
+    ActiveSupport::IsolatedExecutionState.isolation_level = level
+    yield
+  ensure
+    ActiveSupport::IsolatedExecutionState.isolation_level = previous
+  end
+
+  # Generic primitive check: covers ALL four axn keys at once, since they share this one mechanism.
+  describe "ActiveSupport::IsolatedExecutionState (the mechanism every axn key rides)" do
+    # Fiber A sets a key and suspends; B reads it. Returns what B observed.
+    def value_b_sees_after_a_sets(value)
+      fiber_a = Fiber.new do
+        ActiveSupport::IsolatedExecutionState[:_axn_isolation_probe] = value
+        Fiber.yield
+      end
+      fiber_a.resume # set the key, then suspend
+
+      observed = nil
+      Fiber.new do
+        observed = ActiveSupport::IsolatedExecutionState[:_axn_isolation_probe]
+      end.resume
+
+      fiber_a.resume # let A finish cleanly
+      observed
+    end
+
+    it "is isolated per fiber when the host sets isolation_level = :fiber (axn's guarantee)" do
+      with_isolation_level(:fiber) do
+        expect(value_b_sees_after_a_sets("from-a")).to be_nil
+      end
+    end
+
+    it "is shared across fibers under the default :thread (characterizes why a fiber host must opt into :fiber)" do
+      with_isolation_level(:thread) do
+        expect(value_b_sees_after_a_sets("from-a")).to eq("from-a")
+      end
+    end
+  end
+
+  describe "axn's nesting stack" do
+    # Fiber A opens a call tree and suspends with :a on the stack; B opens its own and reports the
+    # stack it observes.
+    def stack_b_observes
+      fiber_a = Fiber.new do
+        Axn::Core::NestingTracking.tracking(:a) { Fiber.yield }
+      end
+      fiber_a.resume # push :a, suspend
+
+      observed = nil
+      Fiber.new do
+        Axn::Core::NestingTracking.tracking(:b) do
+          observed = Axn::Core::NestingTracking._current_axn_stack.dup
+        end
+      end.resume
+
+      fiber_a.resume # drain :a
+      observed
+    end
+
+    it "stays isolated per fiber when the host sets isolation_level = :fiber (axn's guarantee)" do
+      with_isolation_level(:fiber) do
+        expect(stack_b_observes).to eq(%i[b])
+      end
+    end
+
+    it "is shared across fibers under the default :thread (characterizes why a fiber host must opt into :fiber)" do
+      with_isolation_level(:thread) do
+        expect(stack_b_observes).to eq(%i[a b])
+      end
+    end
+  end
+end

--- a/spec/axn/core/fiber_isolation_warning_spec.rb
+++ b/spec/axn/core/fiber_isolation_warning_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# axn keeps all per-execution shared state in ActiveSupport::IsolatedExecutionState, which is scoped
+# by `isolation_level`. Under the default :thread, concurrent fibers on one thread share that state —
+# so a fiber-based host (async/Falcon) that hasn't set `:fiber` would silently corrupt axn's nesting
+# stack and exception-classification sets. We can't fix that for the host (flipping the global at
+# runtime calls IsolatedExecutionState.clear and would nuke AR/CurrentAttributes), but we CAN detect
+# the dangerous combination — a fiber scheduler is installed AND isolation_level is :thread — and warn.
+RSpec.describe "Fiber isolation mismatch warning" do
+  let(:logger) { instance_double(Logger, warn: nil, debug: nil, info: nil, error: nil) }
+
+  before do
+    allow(Axn.config).to receive(:logger).and_return(logger)
+    # warn-once is process-global; reset so each example starts fresh
+    Axn::Core::NestingTracking.instance_variable_set(:@_isolation_mismatch_warned, false)
+    stub_const("NoopAxn", build_axn { def call = nil })
+  end
+
+  def run_noop_axn = NoopAxn.call
+
+  context "when a fiber scheduler is active under :thread isolation" do
+    before { allow(Fiber).to receive(:scheduler).and_return(Object.new) }
+
+    it "warns about the isolation_level mismatch" do
+      run_noop_axn
+      expect(logger).to have_received(:warn).with(/isolation_level/i).once
+    end
+
+    it "warns only once across multiple call trees" do
+      run_noop_axn
+      run_noop_axn
+      run_noop_axn
+      expect(logger).to have_received(:warn).with(/isolation_level/i).once
+    end
+  end
+
+  context "when no fiber scheduler is present (plain threads / Sidekiq)" do
+    before { allow(Fiber).to receive(:scheduler).and_return(nil) }
+
+    it "does not warn" do
+      run_noop_axn
+      expect(logger).not_to have_received(:warn)
+    end
+  end
+
+  context "when isolation_level is already :fiber" do
+    around do |example|
+      previous = ActiveSupport::IsolatedExecutionState.isolation_level
+      ActiveSupport::IsolatedExecutionState.isolation_level = :fiber
+      example.run
+    ensure
+      ActiveSupport::IsolatedExecutionState.isolation_level = previous
+    end
+
+    before { allow(Fiber).to receive(:scheduler).and_return(Object.new) }
+
+    it "does not warn (host has correctly opted into fiber isolation)" do
+      run_noop_axn
+      expect(logger).not_to have_received(:warn)
+    end
+  end
+end

--- a/spec/axn/no_unscoped_execution_state_spec.rb
+++ b/spec/axn/no_unscoped_execution_state_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+# axn's fiber-safety rests on a single invariant: per-execution shared state lives ONLY in
+# ActiveSupport::IsolatedExecutionState (which inherits the host's isolation_level), and never in
+# storage that is hardcoded to the thread or shared at the class level. The patterns banned below are
+# precisely the ones that isolation_level CANNOT save you from — they would leak across fibers (and,
+# for class variables, across everything) no matter how the host is configured.
+#
+# If you genuinely need ambient per-execution state, use ActiveSupport::IsolatedExecutionState[...].
+# See docs/advanced/concurrency.md.
+RSpec.describe "no unscoped per-execution state in lib/" do
+  let(:lib_root) { Pathname.new(File.expand_path("../../lib", __dir__)) }
+
+  let(:forbidden_patterns) do
+    {
+      "Thread.current[...] thread-local (use ActiveSupport::IsolatedExecutionState)" => /Thread\.current\s*\[/,
+      "Thread#thread_variable_get/set (use ActiveSupport::IsolatedExecutionState)" => /\.thread_variable_(get|set)\b/,
+      "@@class_variable (shared across all instances/subclasses; not concurrency-safe)" => /(?<![A-Za-z0-9_])@@[a-z_]/,
+    }
+  end
+
+  it "uses no thread-locals or class variables for state" do
+    offenders = []
+
+    Dir.glob(lib_root.join("**", "*.rb")).each do |path|
+      rel = Pathname.new(path).relative_path_from(lib_root)
+      File.foreach(path).with_index(1) do |line, lineno|
+        forbidden_patterns.each do |label, pattern|
+          offenders << "#{rel}:#{lineno}  [#{label}]  #{line.strip}" if line.match?(pattern)
+        end
+      end
+    end
+
+    expect(offenders).to be_empty, <<~MSG
+      Found per-execution state stored outside ActiveSupport::IsolatedExecutionState.
+      These patterns leak across fibers regardless of isolation_level. See docs/advanced/concurrency.md.
+
+      #{offenders.join("\n")}
+    MSG
+  end
+end


### PR DESCRIPTION
[PRO-2816](https://linear.app/teamshares/issue/PRO-2816/axn-improve-async-support)

## Context

axn keeps all per-execution *shared* state in `ActiveSupport::IsolatedExecutionState` (the nesting stack, exception report-dedup / `fails_on` sets, async retry context). Everything else is per-instance, created fresh per `call`. `IsolatedExecutionState`'s scoping follows the host's `isolation_level`, which defaults to `:thread`:

- **Thread-based concurrency** (Sidekiq, Puma): `:thread` is correct — each thread gets its own state. Safe today, nothing to configure.
- **Fiber-based concurrency** (async / Falcon) left at `:thread`: concurrent fibers on one thread share that state → the nesting stack and classification sets would silently bleed.

An audit confirmed there are **no** thread-locals, `@@`vars, globals, or class-level state holding execution data — so nothing leaks *beyond* what `isolation_level` already governs. The primitive choice is already right; this PR makes the fiber-readiness contract explicit instead of implicit.

## What this does

The gem deliberately does **not** set `isolation_level` itself — it's a host-global that also governs ActiveRecord/`CurrentAttributes`, and assigning it at runtime calls `IsolatedExecutionState.clear`. Instead:

- **Detect-and-warn guard** (`lib/axn/core/nesting_tracking.rb`): warns once when a `Fiber.scheduler` is active while `isolation_level == :thread`, pointing at the fix. Read-only; no host mutation; silent under plain threads.
- **Fiber-isolation regression test** (`spec/axn/core/fiber_isolation_spec.rb`): proves state isolates per-fiber under `:fiber` (axn's guarantee) and characterizes the shared-under-`:thread` behavior the warning addresses. Uses raw `Fiber` interleaving — no async-gem dependency.
- **Invariant guardrail** (`spec/axn/no_unscoped_execution_state_spec.rb`): fails the build if `Thread.current[`, `thread_variable_*`, or `@@` appear in `lib/` — the patterns `isolation_level` can't save.
- **Docs** (`docs/advanced/concurrency.md`): the contract, the one knob, how to use async in an action, and the lazy-init / child-fiber caveats.

Out of scope (deliberately deferred / YAGNI): a fiber-based execution *adapter* (in-process `:async` reactor). The adapter registry remains a clean extension point if a real I/O-bound fan-out use case arrives.