### PR TITLE
PRO-2818: Add Datadog dashboards recipe + docs link checker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,3 +80,18 @@ jobs:
         bundle install --path vendor/bundle
     - name: Run Rails specs
       run: bundle exec rake spec_rails
+
+  docs_links:
+    runs-on: ubuntu-latest
+    name: Docs Link Check
+    steps:
+    - uses: actions/checkout@v7
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24
+        cache: yarn
+    - name: Install dependencies
+      run: yarn install
+    - name: Build docs and verify internal links
+      run: yarn docs:check

--- a/docs/.vitepress/check-links.mjs
+++ b/docs/.vitepress/check-links.mjs
@@ -1,0 +1,110 @@
+// Validates internal doc links — both page targets and #anchors — against the
+// actually-generated HTML in docs/.vitepress/dist. VitePress's own dead-link
+// check does not validate anchor fragments, so those rot silently otherwise.
+//
+// Usage: yarn docs:build && node docs/.vitepress/check-links.mjs
+// Exits non-zero (and prints every broken link) if anything fails to resolve.
+
+import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
+import { join, dirname, resolve, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DOCS = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const DIST = join(DOCS, ".vitepress", "dist");
+
+if (!existsSync(DIST)) {
+  console.error(`No build output at ${DIST}. Run \`yarn docs:build\` first.`);
+  process.exit(2);
+}
+
+// Recursively collect files matching a predicate.
+function walk(dir, pred, acc = []) {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (name === "node_modules" || name === "dist") continue;
+      walk(full, pred, acc);
+    } else if (pred(full)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+// Map every built .html file -> Set of element ids it defines.
+const idCache = new Map();
+function idsFor(htmlPath) {
+  if (idCache.has(htmlPath)) return idCache.get(htmlPath);
+  const ids = new Set();
+  if (existsSync(htmlPath)) {
+    const html = readFileSync(htmlPath, "utf8");
+    for (const m of html.matchAll(/\bid="([^"]+)"/g)) ids.add(m[1]);
+    for (const m of html.matchAll(/\bname="([^"]+)"/g)) ids.add(m[1]);
+  }
+  idCache.set(htmlPath, ids);
+  return ids;
+}
+
+// Resolve a markdown link target to its built .html path.
+// `srcRoute` is the source file's route dir (e.g. "/reference").
+function resolveTarget(target, srcRoute) {
+  let pathPart = target;
+  if (pathPart.startsWith("/")) {
+    pathPart = pathPart.slice(1);
+  } else {
+    pathPart = relative(DOCS, resolve(join(DOCS, srcRoute.slice(1)), pathPart));
+  }
+  if (pathPart === "" || pathPart.endsWith("/")) pathPart += "index";
+  if (pathPart.endsWith(".md")) pathPart = pathPart.slice(0, -3);
+  if (!pathPart.endsWith(".html")) pathPart += ".html";
+  return join(DIST, pathPart);
+}
+
+const mdFiles = walk(DOCS, (f) => f.endsWith(".md"));
+const linkRe = /\[(?:[^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+const failures = [];
+
+for (const md of mdFiles) {
+  const lines = readFileSync(md, "utf8").split("\n");
+  // Route of the source file relative to docs root, e.g. "/reference".
+  const srcRoute = "/" + (relative(DOCS, dirname(md)) || "");
+  let inFence = false;
+  lines.forEach((line, i) => {
+    if (/^\s*```/.test(line)) inFence = !inFence;
+    if (inFence) return;
+    for (const m of line.matchAll(linkRe)) {
+      const raw = m[1];
+      if (/^(https?:|mailto:|tel:|#?$)/.test(raw)) {
+        // External or empty. Pure same-page anchors handled below via leading '#'.
+        if (!raw.startsWith("#")) continue;
+      }
+      const [path, hash] = raw.split("#");
+      const htmlPath = path === "" ? mdToHtml(md) : resolveTarget(path, srcRoute);
+      const where = `${relative(DOCS, md)}:${i + 1}`;
+      if (!existsSync(htmlPath)) {
+        failures.push(`${where}  ->  ${raw}  (page not found: ${relative(DIST, htmlPath)})`);
+        continue;
+      }
+      if (hash) {
+        const ids = idsFor(htmlPath);
+        if (!ids.has(hash)) {
+          failures.push(`${where}  ->  ${raw}  (no #${hash} in ${relative(DIST, htmlPath)})`);
+        }
+      }
+    }
+  });
+}
+
+function mdToHtml(md) {
+  const rel = relative(DOCS, md).replace(/\.md$/, ".html");
+  return join(DIST, rel);
+}
+
+if (failures.length) {
+  console.error(`\n✗ ${failures.length} broken internal doc link(s):\n`);
+  for (const f of failures) console.error("  " + f);
+  console.error("");
+  process.exit(1);
+}
+console.log(`✓ all internal doc links resolve (${mdFiles.length} files checked)`);

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -59,6 +59,7 @@ export default defineConfig({
           { text: 'Validating User Input', link: '/recipes/validating-user-input' },
           { text: 'Testing Actions', link: '/recipes/testing' },
           { text: 'Wrapping External Service Clients', link: '/recipes/wrapping-external-clients' },
+          { text: 'Dashboards from Axn Metrics', link: '/recipes/datadog-dashboards' },
           { text: 'RuboCop Integration', link: '/recipes/rubocop-integration' },
           { text: 'Suppressing Duplicate Async Reports', link: '/recipes/suppressing-duplicate-async-reports' },
           { text: 'Configuration for Axn-based Gems', link: '/recipes/gem-configuration' },

--- a/docs/intro/overview.md
+++ b/docs/intro/overview.md
@@ -131,7 +131,7 @@ For _known_ failure modes, you can call `fail!("Some user-facing explanation")` 
 
 ### Internal errors (uncaught `raise`)
 
-Any exceptions will be swallowed and the action failed (i.e. _not_ `ok?`). `result.error` will be set to a generic error message ("Something went wrong" by default, but [highly configurable](/reference/class#messages)).
+Any exceptions will be swallowed and the action failed (i.e. _not_ `ok?`). `result.error` will be set to a generic error message ("Something went wrong" by default, but [highly configurable](/reference/class#success-and-error)).
 
 The swallowed exception will be available on `result.exception` for your introspection, but it'll also be passed to your `on_exception` handler so, [with a bit of configuration](/usage/setup), you can trust that any exceptions have been logged to your error tracking service automatically (one more thing the dev doesn't need to think about).
 

--- a/docs/recipes/datadog-dashboards.md
+++ b/docs/recipes/datadog-dashboards.md
@@ -1,0 +1,48 @@
+# Dashboards from Axn Metrics
+
+Once you've wired up [`emit_metrics`](/reference/configuration#emit-metrics) and (optionally) [OpenTelemetry tracing](/reference/configuration#opentelemetry-tracing), every action execution is already emitting telemetry. This recipe is about the next step: turning that telemetry into dashboards you actually look at.
+
+This is a **convention, not a framework requirement**. Axn deliberately doesn't ship dashboard tooling or couple itself to any metrics backend — `emit_metrics` is the seam, and what you build on top is yours. The examples below use Datadog because it's a common target, but the shape transfers to any provider.
+
+## Start from a stable metric + tag schema
+
+Dashboards are only as reusable as the metric they query. The single most useful decision is to emit **one count metric for all actions**, tagged by `resource` and `outcome`, rather than a differently-named metric per action:
+
+```ruby
+# config/initializers/axn.rb
+Axn.configure do |c|
+  c.emit_metrics = proc do |resource:, result:|
+    StatsD.increment("axn.call", tags: { resource:, outcome: result.outcome.to_s })
+  end
+end
+```
+
+This gives you one metric (`axn.call`) tagged with `resource:` (the action class name) and `outcome:` (`success` / `failure` / `exception`). Because every action shares one metric name, a single dashboard can render the whole fleet, and drilling into one action is just adding a `resource:` filter — no per-action dashboard wiring required.
+
+::: warning Keep tags bounded
+Tag only with values from a known, finite set — `resource` (the set of action classes) and `outcome` (three values) are safe. Never tag with IDs, emails, or other per-call values: unbounded tag cardinality is what drives metrics cost and slows queries. See the [cardinality note](/reference/configuration#emit-metrics) on `emit_metrics`.
+:::
+
+If you also want latency, emit a distribution from `result.elapsed_time` under the same tag schema (e.g. `axn.call.duration`). Distributions cost more per series than counts, so confirm your `resource` set is bounded first — but at the scale of "number of action classes," it's negligible.
+
+## Two dashboards, two altitudes
+
+A pair of dashboards covers most needs:
+
+**1. A fleet overview** — one per app/service, answering "is everything healthy?":
+
+- Total throughput (`axn.call.count` over time)
+- Outcome mix and error rate (`outcome:failure` + `outcome:exception` over total)
+- **Top actions by failure** (`sum:axn.call.count{outcome:failure} by {resource}`) — this surfaces a single misbehaving action instantly
+- Top actions by volume, and by exception
+- Latency percentiles (p50/p95/p99) once you're emitting `axn.call.duration`
+
+**2. A per-action drill-down** — the same widgets scoped to one `resource`, for when the overview points you at a specific action.
+
+Because both are built from the same `axn.call` schema, the per-action view is just the overview with a `resource:` filter applied — which is what makes a single template reusable across every action and every Axn-based app (each one only supplies its own `service` name).
+
+::: tip A "dead pipeline" alarm
+The most valuable single monitor is often the simplest: alert when `axn.call.count{service:your-app}` drops to ~zero. That rarely means your actions stopped running — it usually means the metrics pipeline itself broke (a bad deploy, a misconfigured agent), which otherwise fails silently and leaves every other widget looking deceptively calm.
+:::
+
+Once you've settled on dashboards worth keeping, store their definitions in version control rather than hand-editing in the UI — most providers expose a dashboards API you can drive from a rake task to create or update them reproducibly.

--- a/docs/recipes/datadog-dashboards.md
+++ b/docs/recipes/datadog-dashboards.md
@@ -31,9 +31,9 @@ A pair of dashboards covers most needs:
 
 **1. A fleet overview** — one per app/service, answering "is everything healthy?":
 
-- Total throughput (`axn.call.count` over time)
+- Total throughput (`sum:axn.call{*}.as_count()` over time) — DogStatsD stores the counter as a per-second rate, so apply `.as_count()` wherever you want raw totals
 - Outcome mix and error rate (`outcome:failure` + `outcome:exception` over total)
-- **Top actions by failure** (`sum:axn.call.count{outcome:failure} by {resource}`) — this surfaces a single misbehaving action instantly
+- **Top actions by failure** (`sum:axn.call{outcome:failure} by {resource}.as_count()`) — this surfaces a single misbehaving action instantly
 - Top actions by volume, and by exception
 - Latency percentiles (p50/p95/p99) once you're emitting `axn.call.duration`
 
@@ -42,7 +42,7 @@ A pair of dashboards covers most needs:
 Because both are built from the same `axn.call` schema, the per-action view is just the overview with a `resource:` filter applied — which is what makes a single template reusable across every action and every Axn-based app (each one only supplies its own `service` name).
 
 ::: tip A "dead pipeline" alarm
-The most valuable single monitor is often the simplest: alert when `axn.call.count{service:your-app}` drops to ~zero. That rarely means your actions stopped running — it usually means the metrics pipeline itself broke (a bad deploy, a misconfigured agent), which otherwise fails silently and leaves every other widget looking deceptively calm.
+The most valuable single monitor is often the simplest: alert when `sum:axn.call{service:your-app}.as_count()` drops to ~zero. That rarely means your actions stopped running — it usually means the metrics pipeline itself broke (a bad deploy, a misconfigured agent), which otherwise fails silently and leaves every other widget looking deceptively calm.
 :::
 
 Once you've settled on dashboards worth keeping, store their definitions in version control rather than hand-editing in the UI — most providers expose a dashboards API you can drive from a rake task to create or update them reproducibly.

--- a/docs/recipes/datadog-dashboards.md
+++ b/docs/recipes/datadog-dashboards.md
@@ -31,9 +31,9 @@ A pair of dashboards covers most needs:
 
 **1. A fleet overview** — one per app/service, answering "is everything healthy?":
 
-- Total throughput (`sum:axn.call{*}.as_count()` over time) — DogStatsD stores the counter as a per-second rate, so apply `.as_count()` wherever you want raw totals
+- Total throughput (`sum:axn.call.count{*}.as_count()` over time) — DogStatsD stores the counter as a per-second rate, so apply `.as_count()` wherever you want raw totals
 - Outcome mix and error rate (`outcome:failure` + `outcome:exception` over total)
-- **Top actions by failure** (`sum:axn.call{outcome:failure} by {resource}.as_count()`) — this surfaces a single misbehaving action instantly
+- **Top actions by failure** (`sum:axn.call.count{outcome:failure} by {resource}.as_count()`) — this surfaces a single misbehaving action instantly
 - Top actions by volume, and by exception
 - Latency percentiles (p50/p95/p99) once you're emitting `axn.call.duration`
 
@@ -42,7 +42,7 @@ A pair of dashboards covers most needs:
 Because both are built from the same `axn.call` schema, the per-action view is just the overview with a `resource:` filter applied — which is what makes a single template reusable across every action and every Axn-based app (each one only supplies its own `service` name).
 
 ::: tip A "dead pipeline" alarm
-The most valuable single monitor is often the simplest: alert when `sum:axn.call{service:your-app}.as_count()` drops to ~zero. That rarely means your actions stopped running — it usually means the metrics pipeline itself broke (a bad deploy, a misconfigured agent), which otherwise fails silently and leaves every other widget looking deceptively calm.
+The most valuable single monitor is often the simplest: alert when `sum:axn.call.count{service:your-app}.as_count()` drops to ~zero. That rarely means your actions stopped running — it usually means the metrics pipeline itself broke (a bad deploy, a misconfigured agent), which otherwise fails silently and leaves every other widget looking deceptively calm.
 :::
 
 Once you've settled on dashboards worth keeping, store their definitions in version control rather than hand-editing in the UI — most providers expose a dashboards API you can drive from a rake task to create or update them reproducibly.

--- a/docs/recipes/datadog-dashboards.md
+++ b/docs/recipes/datadog-dashboards.md
@@ -31,9 +31,9 @@ A pair of dashboards covers most needs:
 
 **1. A fleet overview** — one per app/service, answering "is everything healthy?":
 
-- Total throughput (`sum:axn.call.count{*}.as_count()` over time) — DogStatsD stores the counter as a per-second rate, so apply `.as_count()` wherever you want raw totals
+- Total throughput (`sum:axn.call{*}.as_count()` over time) — DogStatsD stores the counter as a per-second rate, so apply `.as_count()` wherever you want raw totals
 - Outcome mix and error rate (`outcome:failure` + `outcome:exception` over total)
-- **Top actions by failure** (`sum:axn.call.count{outcome:failure} by {resource}.as_count()`) — this surfaces a single misbehaving action instantly
+- **Top actions by failure** (`sum:axn.call{outcome:failure} by {resource}.as_count()`) — this surfaces a single misbehaving action instantly
 - Top actions by volume, and by exception
 - Latency percentiles (p50/p95/p99) once you're emitting `axn.call.duration`
 
@@ -42,7 +42,7 @@ A pair of dashboards covers most needs:
 Because both are built from the same `axn.call` schema, the per-action view is just the overview with a `resource:` filter applied — which is what makes a single template reusable across every action and every Axn-based app (each one only supplies its own `service` name).
 
 ::: tip A "dead pipeline" alarm
-The most valuable single monitor is often the simplest: alert when `sum:axn.call.count{service:your-app}.as_count()` drops to ~zero. That rarely means your actions stopped running — it usually means the metrics pipeline itself broke (a bad deploy, a misconfigured agent), which otherwise fails silently and leaves every other widget looking deceptively calm.
+The most valuable single monitor is often the simplest: alert when `sum:axn.call{service:your-app}.as_count()` drops to ~zero. That rarely means your actions stopped running — it usually means the metrics pipeline itself broke (a bad deploy, a misconfigured agent), which otherwise fails silently and leaves every other widget looking deceptively calm.
 :::
 
 Once you've settled on dashboards worth keeping, store their definitions in version control rather than hand-editing in the UI — most providers expose a dashboards API you can drive from a rake task to create or update them reproducibly.

--- a/docs/recipes/wrapping-external-clients.md
+++ b/docs/recipes/wrapping-external-clients.md
@@ -1,6 +1,6 @@
 # Wrapping External Service Clients
 
-A convention several Axn-based apps have converged on: wrap each external service (a third-party API, a vendor SDK, an internal service) in a single class that `include`s `Axn`, memoizes the underlying connection, and mounts one action per operation via [`mount_axn_method`](/advanced/mountable#mount_axn_method-strategy).
+A convention several Axn-based apps have converged on: wrap each external service (a third-party API, a vendor SDK, an internal service) in a single class that `include`s `Axn`, memoizes the underlying connection, and mounts one action per operation via [`mount_axn_method`](/advanced/mountable#mount-axn-method-strategy).
 
 This is a **convention, not a framework requirement** — nothing in Axn enforces it. It's written up here because it has been consistently useful, and because the choice of `mount_axn_method` (rather than `mount_axn`) is deliberate in a way that's worth understanding before you copy the pattern.
 

--- a/docs/reference/async.md
+++ b/docs/reference/async.md
@@ -105,7 +105,7 @@ SendReport.call_async(occurred_at: Time.current)        # ✅ arrives as a Time 
 SendReport.call_async(occurred_at: Tempfile.new("rpt")) # ✗ raises Axn::Async::UnserializableArgument
 ```
 
-The same rules apply to the static arguments passed to [`enqueue_all`](#batch-enqueueing-with-enqueues_each).
+The same rules apply to the static arguments passed to [`enqueue_all`](#batch-enqueueing-with-enqueues-each).
 
 ## Delayed Execution
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -257,23 +257,25 @@ For example, to wire up Datadog metrics:
 ```ruby
   Axn.configure do |c|
     c.emit_metrics = proc do |resource:, result:|
-      TS::Metrics.increment("action.#{resource.underscore}", tags: { outcome: result.outcome.to_s, resource: })
-      TS::Metrics.histogram("action.duration", result.elapsed_time, tags: { resource: })
+      TS::Metrics.increment("axn.call", tags: { resource:, outcome: result.outcome.to_s })
+      TS::Metrics.distribution("axn.call.duration", result.elapsed_time, tags: { resource:, outcome: result.outcome.to_s })
     end
   end
 ```
+
+Prefer a **single metric name tagged by `resource`** (as above) over a separate metric name per action (e.g. `"action.#{resource.underscore}"`). One tagged metric lets a single dashboard render the whole fleet and drill into any one action with a `resource:` filter — see [Dashboards from Axn Metrics](/recipes/datadog-dashboards).
 
 You can also define `emit_metrics` to only receive the arguments you need:
 
 ```ruby
   # Only receive resource (if you don't need the result)
   c.emit_metrics = proc do |resource:|
-    TS::Metrics.increment("action.#{resource.underscore}")
+    TS::Metrics.increment("axn.call", tags: { resource: })
   end
 
   # Only receive result (if you don't need the resource)
   c.emit_metrics = proc do |result:|
-    TS::Metrics.increment("action.call", tags: { outcome: result.outcome.to_s })
+    TS::Metrics.increment("axn.call", tags: { outcome: result.outcome.to_s })
   end
 
   # Accept any keyword arguments (receives both)
@@ -600,8 +602,8 @@ Axn.configure do |c|
   # OpenTelemetry tracing is automatic when OpenTelemetry is available
 
   c.emit_metrics = proc do |resource:, result:|
-    Datadog::Metrics.increment("action.#{resource.underscore}", tags: { outcome: result.outcome.to_s })
-    Datadog::Metrics.histogram("action.duration", result.elapsed_time, tags: { resource: })
+    Datadog::Metrics.increment("axn.call", tags: { resource:, outcome: result.outcome.to_s })
+    Datadog::Metrics.distribution("axn.call.duration", result.elapsed_time, tags: { resource:, outcome: result.outcome.to_s })
   end
 
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
+    "docs:preview": "vitepress preview docs",
+    "docs:check-links": "node docs/.vitepress/check-links.mjs",
+    "docs:check": "vitepress build docs && node docs/.vitepress/check-links.mjs"
   }
 }


### PR DESCRIPTION
## What

Documents how to turn Axn telemetry into dashboards, and adds tooling so internal doc links stop rotting silently.

[PRO-2818](https://linear.app/teamshares/issue/PRO-2818/axn-datadog-observability-axn-dashboards-os-buyout)

### New recipe — *Dashboards from Axn Metrics*
Picks up after `emit_metrics` / OpenTelemetry are wired (links to those docs rather than repeating them) and covers:
- Choosing a **stable schema**: one `axn.call` metric tagged by `resource` + `outcome`, so a single dashboard can render the whole fleet and drill into any one action with a filter.
- The **fleet-overview vs per-action** dashboard split, including a top-actions-by-failure panel.
- A **"dead pipeline" monitor** (alert when the metric flatlines — usually a broken pipeline, not idle actions).

The dashboard-as-code rake mechanics are intentionally **deferred** — they'll be added here once validated downstream, rather than documenting an unbuilt API.

### `emit_metrics` examples standardized
All three examples in `configuration.md` used a separate metric name per action (`"action.#{resource.underscore}"`). Switched them to a single `axn.call` metric tagged by `resource`/`outcome` (what production actually does), which is what makes the dashboards above reusable.

### Doc link verifier + CI
VitePress does not validate `#anchor` fragments, so broken anchors ship unnoticed. Added `docs/.vitepress/check-links.mjs` (run via `yarn docs:check`) that validates both page targets and anchors against the generated HTML, and wired it into PR CI. It immediately surfaced — and this PR fixes — pre-existing broken anchors in `overview.md`, `async.md`, and `wrapping-external-clients.md`.

## Verification
- `yarn docs:check` passes (build + link check); the new CI job runs it on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)