### PR TITLE
Remove dead "missing keyword" branch from Extract#arity_error?

### DIFF
--- a/lib/axn/core/field_resolvers/extract.rb
+++ b/lib/axn/core/field_resolvers/extract.rb
@@ -107,7 +107,7 @@ module Axn
         end
 
         def arity_error?(error)
-          error.message.start_with?("wrong number of arguments", "missing keyword")
+          error.message.start_with?("wrong number of arguments")
         end
 
         # The actionable text rides on this exception's own #message (see MethodCallNotPermittedError):


### PR DESCRIPTION
## What

`Axn::Core::FieldResolvers::Extract#arity_error?` matched both `"wrong number of arguments"` and `"missing keyword"`. The `"missing keyword"` prefix is dead code.

## Why it's dead

`arity_error?` is only reached inside the `rescue ArgumentError` block, after two gates:

- `reader_requires_arguments?` (line 86) already bails (`raise_unextractable`) on any reader advertising required positional or keyword params (`:req`/`:keyreq`).
- `reader.source_location` (line 95) re-raises any Ruby-defined reader.

A real Ruby method with required keywords advertises `:keyreq` in `.parameters`, so its "missing keyword" `ArgumentError` is caught at line 86 and never reaches `arity_error?`. The only way "missing keyword" could arrive here is a C-extension reader that misreports its `.parameters` (no `:keyreq`) — a scenario nothing in the codebase or spec suite exercises.

Per the repo convention of not carrying defensive code for cases that can't happen, drop it. The real branch (`"wrong number of arguments"`, e.g. `Array#fetch` called bare) stays.

## Verification

`grep -rn "missing keyword" lib/ spec/` confirms the removed line was the sole reference; `arity_error?` has one call site. No behavior change — pure dead-code removal.