### PR TITLE
PRO-2943: Tool input-validation surfacing (Axn::Tools::Invoker)

### DIFF
--- a/AGENTS-consuming.md
+++ b/AGENTS-consuming.md
@@ -77,6 +77,11 @@ These validations are the **developer contract** (how the action is called) — 
 user-facing copy. For user-facing input validation reach for `use :form`. Full option detail:
 <https://teamshares.github.io/axn/reference/class>.
 
+If this action runs as a tool (via `Axn::Tools::Invoker`, an adapter's runtime for model-supplied
+args), declare a `type:` on every field rather than a defensive per-field `coerce: true` — tool
+calls always coerce, and coercion plus schema reflection (`input_schema`) both key off `type:`.
+See <https://teamshares.github.io/axn/reference/tool-invoker>.
+
 ## Inside `call`
 
 | Helper | Effect |
@@ -263,7 +268,8 @@ with the step name prefixed (`"validate: Email is invalid"`).
 Human docs — <https://teamshares.github.io/axn/>:
 build (`/usage/writing`), use (`/usage/using`), class DSL (`/reference/class`), instance helpers
 (`/reference/instance`), result (`/reference/axn-result`), strategies (`/strategies/`), steps
-(`/usage/steps`), async (`/reference/async`), config (`/reference/configuration`).
+(`/usage/steps`), async (`/reference/async`), config (`/reference/configuration`), tool invoker
+(`/reference/tool-invoker`).
 
 Source entry points (resolve with `bundle show axn`):
 - `lib/axn.rb` — `include Axn` wiring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 * [FEAT] `Axn::Factory.build` accepts the full class-level DSL, so a factory-built Axn can declare everything a hand-written class can: `axn_name:`, `description:`, `semantic_hints:`, and the accumulating `fails_on:`/`tag:`/`dimension:` (each a single spec or a list of specs). Now documented at `/reference/factory`.
 * [FEAT] Class-level `axn_name "…"` and `description "…"`, both inherited. `axn_name` is the single source of an action's display name across logging, the `axn.call` notification `resource` (the Datadog dimension), exception breadcrumbs, and profiling labels — so a factory-built or adapter-wrapped tool reports under one canonical identity. The async enqueue/constantize path still uses the real Ruby class name.
 * [FEAT] `semantic_hints :read_only, :idempotent, :destructive` — an advisory declaration of an action's side-effect profile, inherited and extensible by adapters. Class-level extension primitives (`Axn.extension_config.register_semantic_hint`, `Klass.set_extension_metadata` / `extension_metadata`) let an adapter hang transport-specific config off any Axn with no marker mixin.
+* [FEAT] `Axn::Tools::Invoker` — run an Axn as a tool with auto-coercion and opt-in structured, non-reported inbound-validation surfacing (`user_facing_input_errors`, `reject_undeclared_inputs`); adds `ValidationError#field_errors`. Normal `.call` semantics unchanged. (PRO-2943)
 
 ### Other
 

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -38,6 +38,7 @@ export default defineConfig({
           { text: 'Class Interface', link: '/reference/class' },
           { text: 'Instance Interface', link: '/reference/instance' },
           { text: 'Building from Callables', link: '/reference/factory' },
+          { text: 'Tool Invoker', link: '/reference/tool-invoker' },
           { text: 'Result Interface', link: '/reference/axn-result' },
           { text: 'Async', link: '/reference/async' },
           { text: 'FormObject', link: '/reference/form-object' },

--- a/docs/reference/class.md
+++ b/docs/reference/class.md
@@ -834,3 +834,7 @@ Subfields nest to any depth: a dotted `on:` path (`on: "address.billing"`) and a
 The schema advertises each `type:` as its JSON wire form — so `expects :on, type: Date` shows `{ type: "string", format: "date" }` and `expects :mode, type: Symbol` shows `{ type: "string" }`. Add `coerce:` (see [`coerce`](#coerce) above) so a JSON client sending the string `"2026-07-08"` or `"active"` is parsed into the declared `Date`/`Symbol` — the inbound inverse of how the value serializes on output. Without `coerce:`, core still validates strictly against the Ruby type (a direct Ruby caller must pass a real `Date`).
 :::
 
+::: tip Declare `type:` on every tool input
+[`Axn::Tools::Invoker`](/reference/tool-invoker) (the entry point an adapter uses to run an Axn as a tool) always coerces, so a field only picks up that coercion — and gets a useful entry in the schema above — when it declares a `type:` axn recognizes. Declare `type:` on every tool input rather than reaching for a defensive per-field `coerce: true`; the always-on tool coercion and the schema reflection both key off the same `type:` declaration.
+:::
+

--- a/docs/reference/tool-invoker.md
+++ b/docs/reference/tool-invoker.md
@@ -47,10 +47,12 @@ invoker.call(ListCompanies, { ambient_context: { current_user: attacker_id } }, 
 result = invoker.call(ListCompanies, args)
 
 Axn::Tools::Invoker.input_invalid?(result)
-# equivalent to: result.exception.is_a?(Axn::InboundValidationError)
+# equivalent to: Axn::ValidationError.user_facing?(result.exception)
 ```
 
-`input_invalid?` is mode-independent: it answers `true` whenever the call failed on an inbound contract violation, regardless of whether `user_facing_input_errors:` was on for that profile (i.e. regardless of whether the violation was reported to `on_exception` or surfaced as a non-reported user-facing failure). It's `false` for a deliberate `fail!`, an outbound (`exposes`) violation, or any other raised exception.
+`input_invalid?` answers `true` only when the inbound violation was surfaced as a **user-facing** caller error — a correctable, model-facing failure composed under `user_facing_input_errors:`. An inbound failure that stayed **dev-facing** (a normal reported bug, or one that occurred with the gate off) reported to `on_exception` and is **not** flagged `input_invalid?`, so the adapter returns its generic error rather than telling the model its arguments were wrong. It's also `false` for a deliberate `fail!`, an outbound (`exposes`) violation, or any other raised exception.
+
+Ambient (`on: :ambient_context`) failures stay dev-facing even under `user_facing_input_errors:`. Ambient context is trusted, adapter-supplied input (the Invoker injects it — see the guard above), not model input, so a missing or malformed ambient value is an integration bug: it reports to `on_exception` and `input_invalid?` is `false`. When an ambient violation co-occurs with a model-supplied one, the whole set settles dev-facing and reports (a real bug always pages, with every co-occurring violation in one report).
 
 ## Per-field detail
 

--- a/docs/reference/tool-invoker.md
+++ b/docs/reference/tool-invoker.md
@@ -1,0 +1,82 @@
+---
+outline: deep
+---
+
+# Tool Invoker
+
+`Axn::Tools::Invoker` is the sanctioned entry point for running an Axn **as a tool** — the call path an adapter (MCP, an LLM function-calling bridge, an HTTP tool endpoint) uses to hand model-supplied, untrusted arguments to an Axn class and get back a result it can map into its own wire format.
+
+An adapter builds one `Invoker` per behavior profile it wants (most build a single shared instance) and calls it instead of calling `.call` on the Axn class directly:
+
+```ruby
+invoker = Axn::Tools::Invoker.new(user_facing_input_errors: true, reject_undeclared_inputs: true)
+result = invoker.call(ListCompanies, model_supplied_args, ambient_context: { current_user: })
+```
+
+## Why not just call `.call`?
+
+A normal `Foo.call(**args)` is written for a trusted, in-process Ruby caller: types are asserted strictly (no wire-string coercion), an unrecognized key is silently ignored (a normal Ruby `**kwargs` behavior), and every inbound violation reports to `on_exception` as a developer-facing bug. A tool caller has different needs — the arguments came from a model, not a Ruby caller — and the Invoker is the seam that applies a different, adapter-chosen contract without touching what a direct `.call` does.
+
+## The profile knobs
+
+`Invoker.new` takes two keyword options, both defaulting to `false`:
+
+| Option | Effect |
+| --- | --- |
+| `user_facing_input_errors:` | An inbound contract violation (a top-level or subfield `expects` failure, a `model:` consistency mismatch) settles as a non-reported, user-facing failure — `result.error` carries the composed violation message(s) instead of firing `on_exception`. |
+| `reject_undeclared_inputs:` | A top-level key in `args` that isn't a declared `expects` field becomes an inbound validation error instead of being silently dropped. |
+
+Both are per-call gates threaded through `Axn::Internal::CurrentCallOptions` — they apply to exactly the wrapped `.call` and are cleared before any nested `.call` inside it, so a tool calling another action internally sees ordinary default semantics for that inner call.
+
+Coercion is **not** one of these knobs — it's always on for every `Invoker#call`, regardless of the profile. A tool's arguments are wire data by construction (JSON from a model, form-shaped params), so the Invoker forces `coerce_input_types: true` for the call. This is the one case where axn coerces without the author opting in at the class or global level: the trusted-JSON boundary already implies it. A field's own `coerce:` (or lack of a coercible `type:`) still governs that field — the Invoker only supplies the whole-action default. See [`type:` on every tool input](#type-on-every-tool-input) below for what this means for how you declare a tool's `expects`.
+
+## `ambient_context` guard
+
+An Axn's `ambient_context` (`current_user`, `company`, …) is framework-supplied, never something a caller passes directly — see [`ambient_context`](/reference/class#ambient-context-on-ambient-context) in the class reference. Since `args` is untrusted, model-supplied input, the Invoker strips any `ambient_context` key the model tried to set before the call runs, then merges in the adapter's own trusted `ambient_context:` keyword (if given) after the guard. This means a tool call always resolves ambient context through the adapter's own trusted channel, never through a value smuggled in the tool arguments.
+
+```ruby
+invoker.call(ListCompanies, { ambient_context: { current_user: attacker_id } }, ambient_context: { current_user: real_user })
+# the model-supplied ambient_context is dropped; the call runs with ambient_context: { current_user: real_user }
+```
+
+## Return value and detection
+
+`#call` returns a plain `Axn::Result` — the same object a direct `.call` returns, so an adapter's existing result-mapping code (turning a `Result` into an MCP tool response, an HTTP body, etc.) is unchanged. There is no new `Axn::Result` method for "was this an inbound-contract failure" — detect it via the exception class:
+
+```ruby
+result = invoker.call(ListCompanies, args)
+
+Axn::Tools::Invoker.input_invalid?(result)
+# equivalent to: result.exception.is_a?(Axn::InboundValidationError)
+```
+
+`input_invalid?` is mode-independent: it answers `true` whenever the call failed on an inbound contract violation, regardless of whether `user_facing_input_errors:` was on for that profile (i.e. regardless of whether the violation was reported to `on_exception` or surfaced as a non-reported user-facing failure). It's `false` for a deliberate `fail!`, an outbound (`exposes`) violation, or any other raised exception.
+
+## Per-field detail
+
+`result.error` is the composed sentence (axn's normal message-composition rules — base headline plus reason). For a tool that wants to render field-by-field detail (e.g. an MCP client that highlights which argument was wrong), `Axn::InboundValidationError` exposes the individual violations:
+
+```ruby
+result.exception.field_errors
+#=> [{ field: :limit, message: "Limit is not a number" }, { field: :company_id, message: "Company can't be blank" }]
+```
+
+`field_errors` is only defined on `ValidationError` (and its `InboundValidationError` subclass) — check `input_invalid?`/`result.exception.is_a?(Axn::InboundValidationError)` first.
+
+## `type:` on every tool input
+
+With coercion always on for a tool call, an `expects` field only benefits from that coercion if it declares a `type:` axn recognizes as coercible (`Date`, `DateTime`, `Time`, `Symbol`, `Integer`, `Float`, `:boolean` — see [`coerce`](/reference/class#coerce)) — and the same `type:` is what `input_schema` uses to build the JSON Schema an adapter hands to the model in the first place. Declare a `type:` on every tool input rather than reaching for a defensive per-field `coerce: true`: the Invoker's always-on coercion and the schema reflection both key off it, so one declaration does both jobs.
+
+```ruby
+class ListCompanies
+  include Axn
+  tool
+
+  expects :limit, type: Integer, optional: true    # coerced from "25" and schema'd as integer
+  expects :since, type: Date, optional: true        # coerced from "2026-07-08" and schema'd as string/date
+end
+```
+
+## `coerce_input_types` still governs direct `.call`
+
+The Invoker's always-on coercion is a per-call layer scoped to calls made through it — it does not change the class or global `coerce_input_types` setting (see [Coercing a whole action](/reference/class#coercing-a-whole-action-coerce-input-types)). A direct `SomeAxn.call(...)` from ordinary Ruby code still resolves coercion exactly as it did before: off by default, on only where the class or `Axn.config` opts in.

--- a/internal-docs/plans/2026-07-17-pro-2943-tool-input-validation-surfacing.md
+++ b/internal-docs/plans/2026-07-17-pro-2943-tool-input-validation-surfacing.md
@@ -349,18 +349,17 @@ RSpec.describe "tool invocation gates: user_facing_input_errors" do
     expect(result).not_to be_ok
     expect(result.outcome).to eq("failure")
     expect(result.exception).to be_a(Axn::InboundValidationError)
-    expect(result.error).to include("name")
+    expect(result.error).to match(/name/i)
   end
 
   it "surfaces per-field detail for an inclusion (enum) violation" do
     result = invoke(name: "ok", status: "nope")
-    expect(result.error).to match(/status .*included|is not included/i)
-    expect(result.exception.field_errors.map { |e| e[:field] }).to include(:status)
+    expect(result.error).to match(/not included/i)
   end
 
   it "composes multiple violations into one message" do
     result = invoke(name: 123, status: "nope")
-    expect(result.error).to include("name").and include("status")
+    expect(result.error).to match(/name/i).and match(/status/i)
   end
 
   it "still REPORTS the same inputs on a normal call (no gate)" do
@@ -739,7 +738,7 @@ RSpec.describe Axn::Tools::Invoker do
     result = invoker.call(action, { name: 123, age: 36 })
     expect(result).not_to be_ok
     expect(described_class.input_invalid?(result)).to be(true)
-    expect(result.error).to include("name")
+    expect(result.error).to match(/name/i)
   end
 
   it "input_invalid? is false for a fail! / success" do

--- a/internal-docs/plans/2026-07-17-pro-2943-tool-input-validation-surfacing.md
+++ b/internal-docs/plans/2026-07-17-pro-2943-tool-input-validation-surfacing.md
@@ -1,0 +1,989 @@
+# PRO-2943 — Tool input-validation surfacing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give adapters a first-class way to run an Axn as a tool so inbound-contract violations come back structured and non-reported (not paged as bugs), coercion is auto-applied for the trusted-JSON boundary, and undeclared inputs can optionally be rejected — all opt-in and without changing normal `.call` semantics.
+
+**Architecture:** Two layers. (1) Core: three per-call gates carried on an `IsolatedExecutionState` holder (`Axn::Internal::CurrentCallOptions`), *consumed and cleared* by the executor at the top of `with_contract` so they apply only to the wrapped call and never leak into nested sub-actions. The gates tune existing executor behavior — `coerce_input_types` (a per-call layer over the PRO-2884 setting), `user_facing_input_errors` (compose the whole inbound contract as user-facing, reusing the existing settling), `reject_undeclared_inputs` (undeclared top-level keys become normal inbound errors). (2) Tools: `Axn::Tools::Invoker`, a value object holding an adapter's profile, that sets the gates for one call, strips a smuggled `ambient_context`, runs `.call`, and returns a plain `Axn::Result`. Surfacing rides on the already-public `result.exception` plus a new `InboundValidationError#field_errors`; `Axn::Result` is untouched.
+
+**Tech Stack:** Ruby, ActiveSupport (`IsolatedExecutionState`), ActiveModel (`Errors`), RSpec. Must run **outside Rails** (`spec/`); model-consistency behavior is additionally covered **inside Rails** (`spec_rails/dummy_app`).
+
+## Global Constraints
+
+- **Works outside Rails.** No hard dependency on Rails/ActiveRecord — guard every `Rails`/`ActiveRecord` reference with `defined?(...)`. `spec/` runs without Rails; `spec_rails/dummy_app/` is the Rails app. (from AGENTS.md)
+- **TDD.** Failing test first, then implementation. Bugfixes/behaviors start with a reproducing test. (from AGENTS.md / CONTRIBUTING.md)
+- **Additive at the seam.** Existing canonical behavior stays identical; the new behavior is a distinct axis alongside. Normal `.call` (no gates set) must be byte-for-byte unchanged. (from AGENTS.md)
+- **Reuse the seams.** No parallel validation path — the gates tune the existing `_validate_inbound!` / `_collect_contract_failures` / `_with_effective_coerce` flow and reuse the existing `user_facing` settling. (from AGENTS.md; user memory "mirror layers reuse the source")
+- **Framework state is double-underscored** (`@__call_options`) so user actions can't clobber it; internal-only classes live under `Axn::Internal`. (from AGENTS.md)
+- **No historical comments.** Comments describe current behavior + intrinsic why, never "used to X / now Y" or ticket-review notes. (user memory)
+- **No manual line breaks in Markdown prose** in any docs touched — one line per paragraph. (user memory)
+- **Reflection stays side-effect-free** — this work does NOT touch schema reflection; validation gates run only on the real call path, never during `input_schema` reflection. (user memory)
+
+## Design decisions locked for this plan (beyond the spec)
+
+- **Consume-and-clear, not depth-gating.** The executor reads `CurrentCallOptions` exactly once, at the top of `with_contract`, via `CurrentCallOptions.consume` (returns current value and nils the thread-local). This scopes the profile to the single action the invoker wrapped regardless of nesting depth: a nested `.call` in the tool body finds the holder already cleared and runs with default semantics. Chosen over gating on `NestingTracking` stack size (which breaks if a tool is itself invoked from within another action).
+- **`coerce_input_types` per-call is tri-state via nil.** The holder stores `coerce_input_types: nil` meaning "unset — fall back to class/global"; the invoker sets `true`. The executor resolves `per_call.nil? ? resolve_override_for(...) : per_call`. Field-level explicit `coerce:` still wins (unchanged `_with_effective_coerce`).
+- **Undeclared-input allow-list = declared top-level wire roots ∪ `:ambient_context`.** Computed from each inbound config's resolved path `wire_path.first` (top-level fields fall back to `config.field`), unioned with the reserved ambient parent. This exempts subfield `on:` roots (which are legitimate top-level wire keys) and the reserved `ambient_context` parent. Top-level only; nested/subfield unknown keys are out of scope.
+- **`user_facing_input_errors` composes model-consistency mismatches and undeclared-input messages too** (as `:base` message parts), via a `base_extras` parameter on `_composed_user_facing_error`. With the gate off, `_undeclared_input_messages` returns `[]`, so `base_extras == mismatches` and the settle logic is identical to today.
+- **No class-level DSL** for `user_facing_input_errors` / `reject_undeclared_inputs` — the only public setter is `Axn::Tools::Invoker` (YAGNI; additive later). `coerce_input_types` keeps its existing class/global setter.
+
+## File Structure
+
+**Create:**
+- `lib/axn/internal/current_call_options.rb` — `Axn::Internal::CurrentCallOptions`: the per-call gate holder (`Data`-backed `Options`, `with`/`consume`/readers over `IsolatedExecutionState`).
+- `lib/axn/tools/invoker.rb` — `Axn::Tools::Invoker`: per-adapter profile value object, reserved-key guard, `#call` returning `Axn::Result`, `.input_invalid?` sugar.
+- `spec/axn/internal/current_call_options_spec.rb` — holder unit tests (set/consume/restore/isolation).
+- `spec/axn/core/tool_invocation_gates_spec.rb` — executor gate behavior (coerce per-call, user_facing_input_errors, reject_undeclared_inputs) driven directly via `CurrentCallOptions.with`.
+- `spec/axn/tools/invoker_spec.rb` — invoker profile→gates mapping, reserved-key guard, return type, sugar.
+- `spec/axn/exceptions_field_errors_spec.rb` — `InboundValidationError#field_errors` shape.
+- `spec_rails/dummy_app/spec/tool_invocation_model_consistency_spec.rb` — user-facing surfacing of a model-consistency mismatch (needs AR).
+
+**Modify:**
+- `lib/axn.rb` — require the two new files.
+- `lib/axn/executor.rb` — consume options in `with_contract`; per-call coerce resolution; gate `_validate_inbound!`; add `_undeclared_input_messages` / `_declared_top_level_keys` helpers; extend `_composed_user_facing_error`.
+- `lib/axn/exceptions.rb` — add `InboundValidationError#field_errors`.
+- `docs/reference/*` + `CHANGELOG.md` + `AGENTS-consuming.md` — document the tool invoker + per-call coerce (final task).
+
+---
+
+### Task 1: `Axn::Internal::CurrentCallOptions` holder
+
+**Files:**
+- Create: `lib/axn/internal/current_call_options.rb`
+- Modify: `lib/axn.rb` (add require)
+- Test: `spec/axn/internal/current_call_options_spec.rb`
+
+**Interfaces:**
+- Produces:
+  - `Axn::Internal::CurrentCallOptions::Options = Data.define(:coerce_input_types, :user_facing_input_errors, :reject_undeclared_inputs)`
+  - `CurrentCallOptions.with(coerce_input_types: nil, user_facing_input_errors: false, reject_undeclared_inputs: false) { ... }` → yields, restores previous on ensure
+  - `CurrentCallOptions.consume` → returns current `Options` (or `nil`) and clears the thread-local
+  - `CurrentCallOptions.current` / `.current=`
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+# spec/axn/internal/current_call_options_spec.rb
+require "spec_helper"
+
+RSpec.describe Axn::Internal::CurrentCallOptions do
+  after { described_class.current = nil }
+
+  it "defaults to no current options" do
+    expect(described_class.current).to be_nil
+  end
+
+  it "sets options within a `with` block and restores afterward" do
+    described_class.with(user_facing_input_errors: true) do
+      expect(described_class.current.user_facing_input_errors).to be(true)
+      expect(described_class.current.coerce_input_types).to be_nil
+      expect(described_class.current.reject_undeclared_inputs).to be(false)
+    end
+    expect(described_class.current).to be_nil
+  end
+
+  it "restores the prior value even when the block raises" do
+    expect do
+      described_class.with(coerce_input_types: true) { raise "boom" }
+    end.to raise_error("boom")
+    expect(described_class.current).to be_nil
+  end
+
+  it "consume returns the current options and clears the holder" do
+    described_class.with(reject_undeclared_inputs: true) do
+      consumed = described_class.consume
+      expect(consumed.reject_undeclared_inputs).to be(true)
+      expect(described_class.current).to be_nil
+    end
+  end
+
+  it "consume returns nil when nothing is set" do
+    expect(described_class.consume).to be_nil
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/axn/internal/current_call_options_spec.rb`
+Expected: FAIL with `uninitialized constant Axn::Internal::CurrentCallOptions`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ruby
+# lib/axn/internal/current_call_options.rb
+# frozen_string_literal: true
+
+module Axn
+  module Internal
+    # Per-call tuning gates set by a caller (today only Axn::Tools::Invoker) and read once by the
+    # executor. Scoped via IsolatedExecutionState (same pattern as Async::CurrentRetryContext) so
+    # nothing rides on `.call`'s kwargs. The executor `consume`s (reads + clears) at the top of its
+    # contract phase, so the gates apply to exactly the wrapped action and a nested `.call` in its
+    # body sees a cleared holder and runs with default semantics.
+    module CurrentCallOptions
+      Options = Data.define(:coerce_input_types, :user_facing_input_errors, :reject_undeclared_inputs)
+
+      class << self
+        def current = ActiveSupport::IsolatedExecutionState[:_axn_call_options]
+        def current=(value) = (ActiveSupport::IsolatedExecutionState[:_axn_call_options] = value)
+
+        def with(coerce_input_types: nil, user_facing_input_errors: false, reject_undeclared_inputs: false)
+          previous = current
+          self.current = Options.new(coerce_input_types:, user_facing_input_errors:, reject_undeclared_inputs:)
+          yield
+        ensure
+          self.current = previous
+        end
+
+        # Read the current options and clear the holder, so the reading action takes sole ownership
+        # and nested sub-actions do not inherit the gates.
+        def consume = current.tap { self.current = nil }
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Wire the require**
+
+In `lib/axn.rb`, add alongside the other `require "axn/internal/..."` lines:
+
+```ruby
+require "axn/internal/current_call_options"
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/axn/internal/current_call_options_spec.rb`
+Expected: PASS (5 examples).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/axn/internal/current_call_options.rb lib/axn.rb spec/axn/internal/current_call_options_spec.rb
+git commit -m "PRO-2943: add CurrentCallOptions per-call gate holder
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Executor consumes options + per-call `coerce_input_types`
+
+**Files:**
+- Modify: `lib/axn/executor.rb` (`with_contract` start; `_collect_contract_failures` coerce line ~505; add resolver helpers)
+- Test: `spec/axn/core/tool_invocation_gates_spec.rb`
+
+**Interfaces:**
+- Consumes: `Axn::Internal::CurrentCallOptions.consume` (Task 1)
+- Produces (private executor helpers used by Tasks 3–4):
+  - `@__call_options` — the consumed `Options` or `nil`
+  - `_coerce_input_types?` → Boolean (per-call layer over class/global)
+  - `_user_facing_input_errors?` → Boolean
+  - `_reject_undeclared_inputs?` → Boolean
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+# spec/axn/core/tool_invocation_gates_spec.rb
+require "spec_helper"
+
+RSpec.describe "tool invocation gates: coerce_input_types" do
+  let(:action) do
+    Class.new do
+      include Axn
+      expects :age, type: Integer
+      expects :count, type: Integer, coerce: false
+      exposes :age, :count
+      def call
+        expose(age:, count:)
+      end
+    end
+  end
+
+  it "coerces a wire string when the per-call gate is set (field lacks explicit coerce:)" do
+    result = Axn::Internal::CurrentCallOptions.with(coerce_input_types: true) do
+      action.call(age: "42", count: 5)
+    end
+    expect(result).to be_ok
+    expect(result.age).to eq(42)
+  end
+
+  it "honors a field-level `coerce: false` even under the per-call gate" do
+    result = Axn::Internal::CurrentCallOptions.with(coerce_input_types: true) do
+      action.call(age: "42", count: "5")
+    end
+    expect(result).not_to be_ok
+    expect(result.exception).to be_a(Axn::InboundValidationError)
+  end
+
+  it "does not coerce on a normal call with no gate set" do
+    result = action.call(age: "42", count: 5)
+    expect(result).not_to be_ok
+  end
+
+  it "does not leak the gate into a nested sub-action" do
+    inner = Class.new do
+      include Axn
+      expects :n, type: Integer
+      def call; end
+    end
+    outer = Class.new do
+      include Axn
+      expects :age, type: Integer
+      define_method(:call) { @inner_result = inner.call(n: "7") }
+      attr_reader :inner_result
+    end
+    result = Axn::Internal::CurrentCallOptions.with(coerce_input_types: true) do
+      outer.call(age: "1")
+    end
+    expect(result).to be_ok
+    expect(result.__action__.inner_result).not_to be_ok # nested "7" was NOT coerced
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/axn/core/tool_invocation_gates_spec.rb`
+Expected: FAIL — the first example returns `age == "42"` / not ok (gate not yet read), and the nested example's inner result is ok (gate leaked or not applied — currently no gate at all so first example fails).
+
+- [ ] **Step 3: Consume options at the top of `with_contract`**
+
+In `lib/axn/executor.rb`, `with_contract` currently begins by calling `_clear_pre_pipeline_memos!`. Add the consume as the very first line:
+
+```ruby
+def with_contract(&block)
+  # Take sole ownership of any per-call gates set by the caller (e.g. Axn::Tools::Invoker),
+  # clearing the holder so a nested `.call` in the body runs with default semantics.
+  @__call_options = Internal::CurrentCallOptions.consume
+
+  _clear_pre_pipeline_memos!
+  # ... rest unchanged
+```
+
+- [ ] **Step 4: Add the resolver helpers**
+
+Add these private helpers to `Executor` (near `_resolved_parent_value`, still under `private`):
+
+```ruby
+# Per-call gate readers. `@__call_options` is the consumed CurrentCallOptions (or nil for a
+# normal call). coerce is tri-state: a nil per-call value falls back to the class/global setting,
+# so a normal call is unchanged; the tool invoker forces `true`.
+def _coerce_input_types?
+  per_call = @__call_options&.coerce_input_types
+  per_call.nil? ? Axn::Configuration.resolve_override_for(@action_class, :coerce_input_types) : per_call
+end
+
+def _user_facing_input_errors? = @__call_options&.user_facing_input_errors || false
+def _reject_undeclared_inputs? = @__call_options&.reject_undeclared_inputs || false
+```
+
+- [ ] **Step 5: Route the coerce read through the helper**
+
+In `_collect_contract_failures`, replace the first line:
+
+```ruby
+coerce_input_types = Axn::Configuration.resolve_override_for(@action_class, :coerce_input_types)
+```
+
+with:
+
+```ruby
+coerce_input_types = _coerce_input_types?
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/axn/core/tool_invocation_gates_spec.rb`
+Expected: PASS (4 examples).
+
+- [ ] **Step 7: Run the full contract/executor suite to prove no regression**
+
+Run: `bundle exec rspec spec/axn/core spec/axn/executor_spec.rb 2>/dev/null; bundle exec rspec spec`
+Expected: PASS (normal `.call` unchanged — the nil-fallback preserves prior behavior).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/axn/executor.rb spec/axn/core/tool_invocation_gates_spec.rb
+git commit -m "PRO-2943: consume per-call options; per-call coerce_input_types layer
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `user_facing_input_errors` gate
+
+**Files:**
+- Modify: `lib/axn/executor.rb` (`_validate_inbound!`, `_composed_user_facing_error`)
+- Test: `spec/axn/core/tool_invocation_gates_spec.rb` (append)
+
+**Interfaces:**
+- Consumes: `_user_facing_input_errors?` (Task 2)
+- Produces: `_composed_user_facing_error(failures, base_extras = [])` (extended signature; used by Task 4)
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+# append to spec/axn/core/tool_invocation_gates_spec.rb
+RSpec.describe "tool invocation gates: user_facing_input_errors" do
+  let(:action) do
+    Class.new do
+      include Axn
+      expects :name, type: String
+      expects :status, type: String, inclusion: { in: %w[active closed] }
+      def call; end
+    end
+  end
+
+  def invoke(**args)
+    Axn::Internal::CurrentCallOptions.with(user_facing_input_errors: true) { action.call(**args) }
+  end
+
+  it "settles a type violation as a non-reported user-facing failure" do
+    expect(Axn.config).not_to receive(:on_exception)
+    result = invoke(name: 123, status: "active")
+    expect(result).not_to be_ok
+    expect(result.outcome).to eq("failure")
+    expect(result.exception).to be_a(Axn::InboundValidationError)
+    expect(result.error).to include("name")
+  end
+
+  it "surfaces per-field detail for an inclusion (enum) violation" do
+    result = invoke(name: "ok", status: "nope")
+    expect(result.error).to match(/status .*included|is not included/i)
+    expect(result.exception.field_errors.map { |e| e[:field] }).to include(:status)
+  end
+
+  it "composes multiple violations into one message" do
+    result = invoke(name: 123, status: "nope")
+    expect(result.error).to include("name").and include("status")
+  end
+
+  it "still REPORTS the same inputs on a normal call (no gate)" do
+    expect(Axn.config).to receive(:on_exception).at_least(:once)
+    result = action.call(name: 123, status: "active")
+    expect(result).not_to be_ok
+    expect(result.outcome).to eq("exception")
+  end
+
+  it "does NOT reclassify a fail! in the body" do
+    failing = Class.new do
+      include Axn
+      def call = fail!("nope")
+    end
+    result = Axn::Internal::CurrentCallOptions.with(user_facing_input_errors: true) { failing.call }
+    expect(result.outcome).to eq("failure")
+    expect(result.exception).not_to be_a(Axn::InboundValidationError)
+    expect(result.error).to eq("nope")
+  end
+
+  it "does NOT reclassify a genuine StandardError in the body (still reports)" do
+    expect(Axn.config).to receive(:on_exception).at_least(:once)
+    boom = Class.new do
+      include Axn
+      def call = raise "kaboom"
+    end
+    result = Axn::Internal::CurrentCallOptions.with(user_facing_input_errors: true) { boom.call }
+    expect(result.outcome).to eq("exception")
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/axn/core/tool_invocation_gates_spec.rb -e "user_facing_input_errors"`
+Expected: FAIL — under the gate, `on_exception` still fires and `result.outcome` is `"exception"` (gate not yet honored).
+
+- [ ] **Step 3: Extend `_composed_user_facing_error` to accept base extras**
+
+In `lib/axn/executor.rb`, replace:
+
+```ruby
+def _composed_user_facing_error(failures)
+  parts = failures.flat_map { |failure| _user_facing_parts(failure) }
+  InboundValidationError.new(_aggregate_errors(failures, []),
+                             user_facing: true, user_facing_message: parts.uniq.to_sentence)
+end
+```
+
+with:
+
+```ruby
+# base_extras are :base-level message strings (model-consistency mismatches and, under
+# reject_undeclared_inputs, unknown-input messages) that compose into the user-facing message and
+# aggregate onto :base. Empty by default, so the per-field-declared path is unchanged.
+def _composed_user_facing_error(failures, base_extras = [])
+  parts = failures.flat_map { |failure| _user_facing_parts(failure) } + base_extras
+  InboundValidationError.new(_aggregate_errors(failures, base_extras),
+                             user_facing: true, user_facing_message: parts.uniq.to_sentence)
+end
+```
+
+- [ ] **Step 4: Gate the settle decision in `_validate_inbound!`**
+
+In `lib/axn/executor.rb`, replace the tail of `_validate_inbound!` (from `mismatches = ...` to the end):
+
+```ruby
+      mismatches = _model_consistency_mismatches(failed_nodes)
+
+      return if failures.empty? && mismatches.empty?
+
+      raise InboundValidationError, _aggregate_errors(failures, mismatches) unless mismatches.empty? && failures.all? { |f| _failure_fully_user_facing?(f) }
+
+      # ... (comment) ...
+      raise _composed_user_facing_error(failures)
+    end
+```
+
+with:
+
+```ruby
+      mismatches = _model_consistency_mismatches(failed_nodes)
+      base_extras = mismatches + _undeclared_input_messages
+
+      return if failures.empty? && base_extras.empty?
+
+      # Tool-invocation opt-in: treat the WHOLE inbound contract as user-facing for this call —
+      # compose every violation (including model-consistency mismatches and unknown-input messages)
+      # into one non-reported failure. No new classification; the existing user_facing settling,
+      # applied contract-wide.
+      raise _composed_user_facing_error(failures, base_extras) if _user_facing_input_errors?
+
+      raise InboundValidationError, _aggregate_errors(failures, base_extras) unless base_extras.empty? && failures.all? { |f| _failure_fully_user_facing?(f) }
+
+      # Resolve the user-facing message — invoking any Symbol/Proc handler — only now, once we know
+      # this is the exception we actually raise, so a discarded reclassification never fires an
+      # expensive/side-effecting handler for nothing.
+      raise _composed_user_facing_error(failures)
+    end
+```
+
+Note: `_undeclared_input_messages` is added in Task 4; add a temporary stub now so this task is independently green:
+
+```ruby
+# Placeholder until Task 4 wires undeclared-input rejection; returns [] so base_extras == mismatches.
+def _undeclared_input_messages = []
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/axn/core/tool_invocation_gates_spec.rb -e "user_facing_input_errors"`
+Expected: PASS (6 examples).
+
+- [ ] **Step 6: Run the full suite (normal-call semantics unchanged)**
+
+Run: `bundle exec rspec spec`
+Expected: PASS — `_undeclared_input_messages` returns `[]`, so with the gate off `base_extras == mismatches` and the settle logic is identical to before.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/axn/executor.rb spec/axn/core/tool_invocation_gates_spec.rb
+git commit -m "PRO-2943: user_facing_input_errors gate composes whole inbound contract
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `reject_undeclared_inputs` gate
+
+**Files:**
+- Modify: `lib/axn/executor.rb` (replace the `_undeclared_input_messages` stub; add `_declared_top_level_keys`)
+- Test: `spec/axn/core/tool_invocation_gates_spec.rb` (append)
+
+**Interfaces:**
+- Consumes: `_reject_undeclared_inputs?` (Task 2), `Axn::Core::AmbientContext::PARENT` (`:ambient_context`)
+- Produces: `_undeclared_input_messages` → `Array<String>` (`"unknown input: <key>"`)
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+# append to spec/axn/core/tool_invocation_gates_spec.rb
+RSpec.describe "tool invocation gates: reject_undeclared_inputs" do
+  let(:action) do
+    Class.new do
+      include Axn
+      expects :name, type: String
+      expects :city, on: :address, type: String # subfield: :address is a legitimate top-level wire root
+      def call; end
+    end
+  end
+
+  it "rejects an undeclared top-level key as an inbound error" do
+    result = Axn::Internal::CurrentCallOptions.with(reject_undeclared_inputs: true, user_facing_input_errors: true) do
+      action.call(name: "ok", address: { city: "NYC" }, bogus: 1)
+    end
+    expect(result).not_to be_ok
+    expect(result.exception).to be_a(Axn::InboundValidationError)
+    expect(result.error).to include("unknown input: bogus")
+  end
+
+  it "exempts declared fields and subfield wire roots" do
+    result = Axn::Internal::CurrentCallOptions.with(reject_undeclared_inputs: true, user_facing_input_errors: true) do
+      action.call(name: "ok", address: { city: "NYC" })
+    end
+    expect(result).to be_ok
+  end
+
+  it "exempts the reserved ambient_context key" do
+    result = Axn::Internal::CurrentCallOptions.with(reject_undeclared_inputs: true, user_facing_input_errors: true) do
+      action.call(name: "ok", address: { city: "NYC" }, ambient_context: {})
+    end
+    expect(result).to be_ok
+  end
+
+  it "does NOT reject undeclared keys NESTED inside a hash field" do
+    result = Axn::Internal::CurrentCallOptions.with(reject_undeclared_inputs: true, user_facing_input_errors: true) do
+      action.call(name: "ok", address: { city: "NYC", zip: "10001" })
+    end
+    expect(result).to be_ok
+  end
+
+  it "silently ignores undeclared keys when the gate is off" do
+    result = action.call(name: "ok", address: { city: "NYC" }, bogus: 1)
+    expect(result).to be_ok
+  end
+
+  it "surfaces an undeclared key as a dev-facing reported bug when user_facing is off but reject is on" do
+    expect(Axn.config).to receive(:on_exception).at_least(:once)
+    result = Axn::Internal::CurrentCallOptions.with(reject_undeclared_inputs: true) do
+      action.call(name: "ok", address: { city: "NYC" }, bogus: 1)
+    end
+    expect(result.outcome).to eq("exception")
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/axn/core/tool_invocation_gates_spec.rb -e "reject_undeclared_inputs"`
+Expected: FAIL — the stub returns `[]`, so `bogus` is silently accepted and the first/last examples fail.
+
+- [ ] **Step 3: Replace the stub with the real helpers**
+
+In `lib/axn/executor.rb`, replace:
+
+```ruby
+def _undeclared_input_messages = []
+```
+
+with:
+
+```ruby
+# Under reject_undeclared_inputs, every provided top-level wire key that is neither a declared
+# field/subfield wire root nor the reserved ambient parent becomes a normal inbound error. Top-level
+# only: keys nested inside a Hash field are not the top-level contract's concern.
+def _undeclared_input_messages
+  return [] unless _reject_undeclared_inputs?
+
+  (@context.provided_data.keys - _declared_top_level_keys).map { |key| "unknown input: #{key}" }
+end
+
+# The set of legitimate top-level wire keys: each inbound config's resolved-path root (top-level
+# fields fall back to their own field name), plus the reserved always-present ambient parent.
+def _declared_top_level_keys
+  roots = _inbound_configs.filter_map do |config|
+    path = _resolved_path_for(config)
+    path ? path.wire_path.first : config.field
+  end
+  (roots + [Core::AmbientContext::PARENT]).uniq
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/axn/core/tool_invocation_gates_spec.rb -e "reject_undeclared_inputs"`
+Expected: PASS (6 examples).
+
+- [ ] **Step 5: Run the full gate spec + suite**
+
+Run: `bundle exec rspec spec/axn/core/tool_invocation_gates_spec.rb && bundle exec rspec spec`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/axn/executor.rb spec/axn/core/tool_invocation_gates_spec.rb
+git commit -m "PRO-2943: reject_undeclared_inputs gate (top-level, ambient-exempt)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `InboundValidationError#field_errors`
+
+**Files:**
+- Modify: `lib/axn/exceptions.rb`
+- Test: `spec/axn/exceptions_field_errors_spec.rb`
+
+**Interfaces:**
+- Produces: `Axn::InboundValidationError#field_errors` → `Array<{field: Symbol, message: String}>`
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+# spec/axn/exceptions_field_errors_spec.rb
+require "spec_helper"
+
+RSpec.describe Axn::InboundValidationError do
+  def errors_with(&block)
+    e = ActiveModel::Errors.new(Axn::Validation::Aggregate.new)
+    block.call(e)
+    e
+  end
+
+  it "maps each error to {field:, message:} using the full message" do
+    errors = errors_with { |e| e.add(:name, "is not a String") }
+    exc = described_class.new(errors)
+    expect(exc.field_errors).to eq([{ field: :name, message: "Name is not a String" }])
+  end
+
+  it "surfaces base-level errors with field == :base" do
+    errors = errors_with { |e| e.add(:base, "unknown input: bogus") }
+    exc = described_class.new(errors)
+    expect(exc.field_errors).to eq([{ field: :base, message: "unknown input: bogus" }])
+  end
+
+  it "is empty when there are no errors" do
+    exc = described_class.new(errors_with { |_e| })
+    expect(exc.field_errors).to eq([])
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/axn/exceptions_field_errors_spec.rb`
+Expected: FAIL with `undefined method 'field_errors'`.
+
+- [ ] **Step 3: Add the accessor**
+
+In `lib/axn/exceptions.rb`, inside `class ValidationError` (so both inbound and outbound inherit it — the adapter only ever reads it off an `InboundValidationError`, but the mapping is generic), add after `def to_s = message`:
+
+```ruby
+    # Structured per-field view of the validation errors, for callers that want to format each
+    # failure individually (e.g. a tool adapter handing per-argument reasons back to a model).
+    # `full_message` so each entry reads standalone; base-level errors surface with field == :base.
+    def field_errors = errors.map { |error| { field: error.attribute, message: error.full_message } }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/axn/exceptions_field_errors_spec.rb`
+Expected: PASS (3 examples).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/axn/exceptions.rb spec/axn/exceptions_field_errors_spec.rb
+git commit -m "PRO-2943: add ValidationError#field_errors structured accessor
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: `Axn::Tools::Invoker`
+
+**Files:**
+- Create: `lib/axn/tools/invoker.rb`
+- Modify: `lib/axn.rb` (add require, near the `axn/tools/registry` require)
+- Test: `spec/axn/tools/invoker_spec.rb`
+
+**Interfaces:**
+- Consumes: `Axn::Internal::CurrentCallOptions.with` (Task 1), `Axn::InboundValidationError` (Task 5)
+- Produces:
+  - `Axn::Tools::Invoker.new(user_facing_input_errors: false, reject_undeclared_inputs: false)`
+  - `#call(axn_class, args = {}, ambient_context: NOT_SET)` → `Axn::Result`
+  - `Axn::Tools::Invoker.input_invalid?(result)` → Boolean
+  - `Axn::Tools::Invoker::RESERVED_INPUT_KEYS` → `%i[ambient_context]`
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+# spec/axn/tools/invoker_spec.rb
+require "spec_helper"
+
+RSpec.describe Axn::Tools::Invoker do
+  let(:action) do
+    Class.new do
+      include Axn
+      expects :name, type: String
+      expects :age, type: Integer
+      exposes :name
+      def call = expose(name:)
+    end
+  end
+
+  it "returns a plain Axn::Result on success" do
+    result = described_class.new.call(action, { name: "ada", age: 36 })
+    expect(result).to be_a(Axn::Result)
+    expect(result).to be_ok
+    expect(result.name).to eq("ada")
+  end
+
+  it "coerces wire strings without any per-field coerce: (coerce always on for tools)" do
+    result = described_class.new.call(action, { name: "ada", age: "36" })
+    expect(result).to be_ok
+  end
+
+  it "surfaces an inbound violation as a non-reported failure when user_facing_input_errors is on" do
+    expect(Axn.config).not_to receive(:on_exception)
+    invoker = described_class.new(user_facing_input_errors: true)
+    result = invoker.call(action, { name: 123, age: 36 })
+    expect(result).not_to be_ok
+    expect(described_class.input_invalid?(result)).to be(true)
+    expect(result.error).to include("name")
+  end
+
+  it "input_invalid? is false for a fail! / success" do
+    ok = described_class.new.call(action, { name: "ada", age: 36 })
+    expect(described_class.input_invalid?(ok)).to be(false)
+  end
+
+  it "strips a model-supplied ambient_context from untrusted args" do
+    sensing = Class.new do
+      include Axn
+      expects :x, type: Integer
+      define_method(:call) { @seen = ambient_context }
+      attr_reader :seen
+    end
+    result = described_class.new.call(sensing, { x: 1, ambient_context: { tenant: "evil" } })
+    expect(result.__action__.seen).to eq({})
+  end
+
+  it "injects the adapter's trusted ambient_context after stripping" do
+    sensing = Class.new do
+      include Axn
+      expects :tenant, on: :ambient_context, type: String
+      exposes :tenant
+      def call = expose(tenant:)
+    end
+    result = described_class.new.call(
+      sensing,
+      { ambient_context: { tenant: "evil" } },
+      ambient_context: { tenant: "trusted" },
+    )
+    expect(result).to be_ok
+    expect(result.tenant).to eq("trusted")
+  end
+
+  it "clears CurrentCallOptions after the call" do
+    described_class.new(user_facing_input_errors: true).call(action, { name: "ada", age: 36 })
+    expect(Axn::Internal::CurrentCallOptions.current).to be_nil
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/axn/tools/invoker_spec.rb`
+Expected: FAIL with `uninitialized constant Axn::Tools::Invoker`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ruby
+# lib/axn/tools/invoker.rb
+# frozen_string_literal: true
+
+module Axn
+  module Tools
+    # The sanctioned entry point for running an Axn AS A TOOL. Holds an adapter's chosen profile and
+    # runs `.call` under the matching per-call gates (Axn::Internal::CurrentCallOptions), returning a
+    # plain Axn::Result so an adapter's existing result-mapping is unchanged. Coercion is always on
+    # for tools (the trusted-JSON boundary wants it, and a field's own `coerce:` still wins); the
+    # user-facing surfacing and undeclared-input rejection are per-adapter opt-ins. Detection of an
+    # input-contract failure rides on the returned result's exception (`input_invalid?`), not on any
+    # new Axn::Result method.
+    class Invoker
+      NOT_SET = Object.new.freeze
+
+      # axn framework-reserved input keys that untrusted (model-supplied) args may not set. Currently
+      # only :ambient_context — direct passing is a valid override for a normal `.call`, but a tool's
+      # args come from the model, so the invoker forces the ambient-resolution pipeline and lets the
+      # adapter inject its own trusted context. NOT :server_context — that is an mcp transport concept
+      # the mcp adapter extracts itself and passes in as the trusted ambient_context.
+      RESERVED_INPUT_KEYS = %i[ambient_context].freeze
+
+      def initialize(user_facing_input_errors: false, reject_undeclared_inputs: false)
+        @user_facing_input_errors = user_facing_input_errors
+        @reject_undeclared_inputs = reject_undeclared_inputs
+      end
+
+      # args: the untrusted, model-supplied argument hash.
+      # ambient_context: the adapter's OWN trusted ambient context (optional), merged after the guard.
+      def call(axn_class, args = {}, ambient_context: NOT_SET)
+        clean = args.reject { |key, _| RESERVED_INPUT_KEYS.include?(key.to_sym) }
+        clean = clean.merge(ambient_context:) unless ambient_context.equal?(NOT_SET)
+
+        Axn::Internal::CurrentCallOptions.with(
+          coerce_input_types: true,
+          user_facing_input_errors: @user_facing_input_errors,
+          reject_undeclared_inputs: @reject_undeclared_inputs,
+        ) do
+          axn_class.call(**clean)
+        end
+      end
+
+      # Whether a returned result failed on an inbound contract violation (as opposed to a `fail!`,
+      # an outbound violation, or a genuine exception). Mode-independent — true regardless of whether
+      # the violation was reported or surfaced as user-facing.
+      def self.input_invalid?(result) = result.exception.is_a?(Axn::InboundValidationError)
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Wire the require**
+
+In `lib/axn.rb`, add next to the tools registry require:
+
+```ruby
+require "axn/tools/invoker"
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/axn/tools/invoker_spec.rb`
+Expected: PASS (7 examples).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/axn/tools/invoker.rb lib/axn.rb spec/axn/tools/invoker_spec.rb
+git commit -m "PRO-2943: add Axn::Tools::Invoker tool-invocation profile
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Rails coverage for model-consistency surfacing
+
+**Files:**
+- Test: `spec_rails/dummy_app/spec/tool_invocation_model_consistency_spec.rb`
+
+**Interfaces:**
+- Consumes: `Axn::Tools::Invoker` (Task 6), the dummy app's existing AR models.
+
+- [ ] **Step 1: Identify an existing dummy-app model with a `model:` id-based field pattern**
+
+Run: `ls spec_rails/dummy_app/app/models && grep -rln "model:" spec_rails/dummy_app/spec | head`
+Expected: a model (e.g. `User`) usable for `expects :user, model: true`. Use whatever the dummy app already provides; adapt the class below to it.
+
+- [ ] **Step 2: Write the failing test**
+
+```ruby
+# spec_rails/dummy_app/spec/tool_invocation_model_consistency_spec.rb
+require "rails_helper"
+
+RSpec.describe "tool invocation: model-consistency mismatch surfaces user-facing" do
+  # Adjust `User` / attributes to a model the dummy app actually defines (see Step 1).
+  let(:action) do
+    Class.new do
+      include Axn
+      expects :user, model: true
+      def call; end
+    end
+  end
+
+  it "composes a record/id mismatch into a non-reported user-facing failure" do
+    user = User.create!
+    other_id = user.id + 1
+    expect(Axn.config).not_to receive(:on_exception)
+    result = Axn::Tools::Invoker.new(user_facing_input_errors: true).call(
+      action, { user:, user_id: other_id },
+    )
+    expect(result).not_to be_ok
+    expect(Axn::Tools::Invoker.input_invalid?(result)).to be(true)
+    expect(result.error).to match(/conflicts with user_id/)
+  end
+end
+```
+
+- [ ] **Step 3: Run test to verify it fails, then passes**
+
+Run (from the dummy app bundle — see AGENTS / user memory "Running axn spec_rails"):
+```bash
+BUNDLE_GEMFILE=spec_rails/dummy_app/Gemfile bundle exec rspec spec_rails/dummy_app/spec/tool_invocation_model_consistency_spec.rb
+```
+Expected: after Tasks 3–6 this PASSES (mismatch composed via `base_extras`). If it FAILS on model setup, fix the fixture to match the dummy app's real models — the behavior under test (mismatch → user-facing) is already implemented.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spec_rails/dummy_app/spec/tool_invocation_model_consistency_spec.rb
+git commit -m "PRO-2943: Rails coverage for model-consistency user-facing surfacing
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Documentation + CHANGELOG
+
+**Files:**
+- Create: `docs/reference/tool-invoker.md` (or extend an existing tools reference page if one exists — check `docs/reference/`)
+- Modify: `CHANGELOG.md`, `AGENTS-consuming.md`
+- Modify: `docs/reference/configuration.md` (or wherever `coerce_input_types` is documented) — note the per-call layer
+
+- [ ] **Step 1: Locate the existing docs surfaces**
+
+Run: `ls docs/reference && grep -rln "coerce_input_types\|tools_for\|tool_name" docs`
+Expected: the tools/config reference pages to extend.
+
+- [ ] **Step 2: Write the tool-invoker reference**
+
+Create `docs/reference/tool-invoker.md` documenting: what `Axn::Tools::Invoker` is (run an Axn as a tool), the profile knobs (`user_facing_input_errors`, `reject_undeclared_inputs`, coerce always-on), that it returns a plain `Axn::Result`, detection via `Axn::Tools::Invoker.input_invalid?(result)` / `result.exception.is_a?(Axn::InboundValidationError)`, per-field detail via `result.error` and `InboundValidationError#field_errors`, and the `ambient_context` reserved-key guard. Include the two-line adapter usage example from the spec. One line per paragraph (no hard wraps).
+
+- [ ] **Step 3: Note the guidance shift**
+
+In the inputs/`type:` guidance doc (find via `grep -rln "expects" docs/guide docs/reference | head`) and in `AGENTS-consuming.md`, add: declare a `type:` on every input — tool coercion and schema reflection both depend on it, so with the invoker's always-on coercion you no longer need defensive `coerce: true` per field. Keep it short; do not restructure surrounding docs.
+
+- [ ] **Step 4: CHANGELOG entry**
+
+Add to `CHANGELOG.md` under the unreleased section (match the existing FEAT-line format):
+
+```
+- **FEAT:** `Axn::Tools::Invoker` — run an Axn as a tool with auto-coercion and opt-in structured, non-reported inbound-validation surfacing (`user_facing_input_errors`, `reject_undeclared_inputs`); adds `ValidationError#field_errors`. Normal `.call` semantics unchanged. (PRO-2943)
+```
+
+- [ ] **Step 5: Verify docs build / links (if the repo has a docs check)**
+
+Run: `grep -rn "tool-invoker" docs` to confirm the page is linked from any index/sidebar; add a sidebar entry if the repo uses one (check `docs/.vitepress/config.*`).
+Expected: the new page is reachable.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs CHANGELOG.md AGENTS-consuming.md
+git commit -m "PRO-2943: document tool invoker + per-call coerce; type: guidance
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Core gate `coerce_input_types` (per-call layer, field-level wins, class/global governs direct call) → Task 2. ✓
+- Core gate `user_facing_input_errors` (compose whole contract, non-reported, reuse settling; only inbound affected) → Task 3. ✓
+- Core gate `reject_undeclared_inputs` (top-level, ambient/subfield-root exempt, nested out of scope) → Task 4. ✓
+- Consume-and-clear scoping (no nested-call leak) → Task 2 (mechanism + nested test). ✓
+- No `Axn::Result` changes; detection via `result.exception`; `InboundValidationError#field_errors`; `Invoker.input_invalid?` sugar → Tasks 5, 6. ✓
+- `Axn::Tools::Invoker` profile + reserved-key guard + trusted ambient injection + returns Result → Task 6. ✓
+- Normal `.call` / `fail!` / outbound / genuine exception unchanged → Tasks 2, 3 (explicit tests). ✓
+- Model-consistency mismatch composes user-facing → Task 3 (unit) + Task 7 (Rails). ✓
+- Downstream adapter migration → out of scope for this repo (captured in spec/ticket; separate adapter PRs). ✓
+- README/`type:` guidance simplification → Task 8. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. The Task 3 `_undeclared_input_messages` stub is intentional and explicitly replaced in Task 4 (keeps Task 3 independently green). Task 7's model fixture is explicitly "adapt to the dummy app's real models" with a discovery step, not a placeholder for behavior. ✓
+
+**Type consistency:** `@__call_options` / `_coerce_input_types?` / `_user_facing_input_errors?` / `_reject_undeclared_inputs?` (Task 2) are consumed verbatim in Tasks 3–4. `_composed_user_facing_error(failures, base_extras = [])` (Task 3) matches its Task 4 usage. `Axn::Tools::Invoker#call(axn_class, args, ambient_context:)` and `.input_invalid?` (Task 6) match the invoker spec and Task 7. `field_errors` shape `{field:, message:}` (Task 5) matches its use in Task 3's inclusion test. ✓

--- a/internal-docs/specs/2026-07-17-tool-input-validation-surfacing-design.md
+++ b/internal-docs/specs/2026-07-17-tool-input-validation-surfacing-design.md
@@ -1,0 +1,159 @@
+# Tool input validation: structured, non-reported inbound surfacing for adapters
+
+Linear: [PRO-2943](https://linear.app/teamshares/issue/PRO-2943/axn-tool-validation-improvements) (parent PRO-1610).
+
+## Context
+
+`axn-ruby_llm` and `axn-mcp` wrap any Axn as an LLM/MCP tool: the model supplies the arguments, and a malformed tool call should come back to the model as a clean, correctable "invalid arguments: <what's wrong>" — not as a generic failure, and not reported as an application bug (a bad LLM tool call isn't a bug in our code).
+
+Today a non-`user_facing:` inbound-contract violation is treated as a dev-facing exception. In `Executor#with_exception_handling` (executor.rb:300) an `InboundValidationError` that is neither a `Failure`, `fails_on`-matched, sticky-failure, nor `user_facing?` falls to `trigger_on_exception` — so it fires the global `on_exception` report and `result.error` shows the generic headline, with no indication of which field or why. For an LLM/MCP boundary that is doubly wrong: (a) routine bad tool calls page `on_exception` as if our code were buggy — a false-positive firehose that erodes the one channel meant to catch real bugs; and (b) the model gets "Something went wrong" instead of an actionable per-field reason it could self-correct from.
+
+The current downstream workaround (to be retired) is a shallow pre-check in `axn-ruby_llm`'s `tool_argument_validator` against the reflected `input_schema`: required-keys, unknown-keys, and top-level JSON type only. It deliberately skips enum/nested/items/format because covering them means re-implementing (and risking divergence from) the validation Axn already performs. So deep violations still fall through to the generic-message + `on_exception` behavior.
+
+## The stance we are NOT changing
+
+Direct `.call` from ordinary app code keeps treating bad inbound data as a **dev issue**: it fires `on_exception` and surfaces the generic error exactly as today. `MyAction.call(name: 123)` from app code genuinely is a programming bug, and the report is the safety net that catches it. The framework's existing stance — inbound violations are dev-facing by default, opt individual fields in with `expects ..., user_facing:` — stands. This work is purely **additive** and **opt-in**; it never sniffs "am I in an adapter" and never globally reclassifies inbound validation.
+
+## Architecture: two layers
+
+The design splits cleanly into a framework-general lower layer and a tool-specific upper layer:
+
+1. **Core (general, per-call gates).** The executor gains per-call gates carried on an execution-context object (`IsolatedExecutionState`, the same pattern as `Async::CurrentRetryContext`) — so nothing rides on `.call`'s kwargs and there is no collision with user field names. These gates are framework-general behaviors, not tool concepts.
+2. **Tools (the profile).** `Axn::Tools::Invoker` — a small value object holding an adapter's chosen profile. Its `#call(axn_class, args, ambient_context:)` sets the core gates for that one invocation, applies the reserved-key guard, runs `.call`, and returns a plain `Axn::Result`.
+
+The public surface added to `Axn::Result` is **nothing**. Detection and per-field detail already live on the exception (`result.exception`), which is already public.
+
+## Part 1 — core per-call gates
+
+A per-call options object (working name `Axn::Internal::CurrentCallOptions`, an `IsolatedExecutionState`-backed current-attributes holder with a `with(**opts) { ... }` block API that saves/restores the prior value). The executor reads it at inbound-validation time. Three gates:
+
+### 1a. `coerce_input_types` (per-call override of the existing setting)
+
+`coerce_input_types` already exists as an overridable setting (PRO-2884); the executor reads it at `_collect_contract_failures` (executor.rb:505) and applies `_with_effective_coerce` to every coercible typed field lacking an explicit `coerce:`. This gate adds a per-call layer above the class/global resolution: the effective value becomes `per_call.nil? ? Configuration.resolve_override_for(@action_class, :coerce_input_types) : per_call`. Tools only ever set it to `true`, so a simpler `per_call || resolve_override_for(...)` is equivalent, but the explicit-nil form documents that per-call is a distinct layer.
+
+**Precedence (unchanged mechanics, one new layer):**
+
+1. Field-level explicit `coerce: true/false` — always wins. `_with_effective_coerce` already returns a field's validations untouched when its `type:` hash carries a `:coerce` key, so a field can opt out of coercion (`coerce: false`) even under a tool invocation.
+2. Per-call gate (set by the invoker) — forces whole-action coercion on for the invoker's path.
+3. Class-level `coerce_input_types` — governs the direct `.call` path.
+4. Global default.
+
+The class/global setting therefore keeps its full value: it governs the **direct** `.call` path (which coexists with the tool path — a tool class is commonly also callable directly), and it remains the general switch for non-tool stringly-typed boundaries (CLI/Thor/Rake args, HTTP `params`, CSV/ETL cells, ENV-driven config). Tools are simply one more such boundary — one that always wants coercion, so the invoker opts in on the author's behalf.
+
+### 1b. `user_facing_input_errors` (downgrade the whole inbound contract to user-facing)
+
+When set, `_validate_inbound!` composes **every** failing config's message as user-facing and settles the `InboundValidationError` as a non-reported failure — no new classification concept, just the existing `user_facing` settling applied contract-wide for one call. Today `_validate_inbound!` (executor.rb:474) raises the dev-facing aggregate unless `mismatches.empty? && failures.all? { |f| _failure_fully_user_facing?(f) }`; with this gate set, it composes and raises `_composed_user_facing_error(failures)` unconditionally (model-consistency mismatches included in the composed message). The resulting `InboundValidationError` is `user_facing?`, so the executor routes it to the failure bucket (no `on_exception`), and `result.error` carries the composed per-field sentence via the existing `_user_provided_error_message` path (result.rb:210).
+
+The name mirrors `expects ..., user_facing:` — this is the tool-invocation analog applied to the whole contract. It conveys both halves the behavior actually has (downgrade-to-failure **and** attach-the-message); a plain "downgrade to failure" framing would read like `fails_on`, which downgrades but leaves `result.error` generic.
+
+Default off. Only inbound violations are affected — a `fail!` in the body, an outbound violation, or a genuine `StandardError` all behave exactly as today (real bugs still page), satisfying the acceptance criterion that genuine unexpected exceptions report exactly as before.
+
+### 1c. `reject_undeclared_inputs` (treat unknown top-level keys as a normal inbound error)
+
+axn stores all provided kwargs and silently ignores undeclared ones (`Context` keeps them; this is necessary in some contexts). When this gate is set, undeclared **top-level** keys become normal inbound validation errors, flowing through the *same* aggregation and (with 1b also set) the same user-facing composition — so an unknown argument surfaces to the model identically to a type/enum violation.
+
+Implementation: in the inbound collection pass, compute `undeclared = provided_data.keys - declared_top_level_fields - framework_reserved_input_keys` and add one error per undeclared key (message: `"unknown input: <key>"`). `declared_top_level_fields` is the set of `internal_field_configs` fields; `framework_reserved_input_keys` is the set of keys the contract recognizes beyond declared fields — currently `:ambient_context` (the reserved always-present parent, ambient_context.rb). The check is **top-level only**: nested keys inside a Hash field are not the top-level contract's concern (an undeclared-subfield policy is out of scope). These errors classify as inbound (user-facing under 1b) and aggregate with the rest.
+
+Default off. This is the opt-in that lets an adapter give the model "unknown input: foo" feedback that the shallow pre-check used to provide, without re-implementing schema depth.
+
+### Public setter for the gates
+
+The gates are framework-general, but for this ticket the **only** sanctioned public way to set 1b/1c is via `Axn::Tools::Invoker` (below). `coerce_input_types` retains its existing class/global setter. We deliberately do **not** add class-level DSL for `user_facing_input_errors` / `reject_undeclared_inputs` now (YAGNI); exposing them per-class later is additive if a real non-tool need appears.
+
+## Part 2 — surfacing (no `Axn::Result` changes)
+
+Detection and detail both come off the already-public exception, so `Axn::Result` — used everywhere, not just by tools — gains nothing (and avoids any risk of shadowing a user's `exposes :input_errors`).
+
+- **Detection:** `result.exception.is_a?(Axn::InboundValidationError)`. `Axn::InboundValidationError` is already a public top-level constant. The predicate is **mode-independent**: true whether the violation was reported as a bug (normal `.call`) or downgraded to a user-facing failure (tool mode). The gate changes reporting and `result.error`'s message, not what the exception *is*. Outbound violations (`OutboundValidationError`) are a different class and are correctly excluded — a bad *output* is always a bug.
+- **Composed message:** `result.error` (already the per-field sentence in user-facing mode).
+- **Structured per-field detail:** `InboundValidationError#errors` is already an iterable `ActiveModel::Errors`. Add one convenience **on the exception** (its natural owner, a low-traffic class): `InboundValidationError#field_errors → [{ field:, message: }]`, mapping `errors` via `{ field: e.attribute, message: e.full_message }` (`full_message` so each entry is standalone-readable; base-level errors surface with `field == :base`).
+- **Optional tool-namespace sugar:** `Axn::Tools::Invoker.input_invalid?(result)` wraps the `is_a?` check, so adapters need not name the exception class directly and the tool concern stays in the tool layer.
+
+## Part 3 — `Axn::Tools::Invoker`
+
+A small value object (class, not a bare method) that owns the per-adapter profile, the reserved-key guard, and the set/clear-gates dance, and returns a plain `Axn::Result` so downstream result-mapping is unchanged. It is a class for cohesion and independent testability (not for speculative flexibility): an adapter constructs one with its profile and reuses it at its single call site.
+
+```ruby
+module Axn
+  module Tools
+    class Invoker
+      NOT_SET = Object.new.freeze
+
+      # axn framework-reserved input keys that untrusted (model-supplied) args may not set.
+      # Currently just :ambient_context. NOT server_context — that is an mcp transport concept
+      # the mcp adapter extracts itself and passes in as the trusted ambient_context below.
+      RESERVED_INPUT_KEYS = %i[ambient_context].freeze
+
+      def initialize(user_facing_input_errors: false, reject_undeclared_inputs: false)
+        @user_facing_input_errors = user_facing_input_errors
+        @reject_undeclared_inputs = reject_undeclared_inputs
+      end
+
+      # args: the untrusted, model-supplied argument hash.
+      # ambient_context: the adapter's OWN trusted ambient context (optional) — merged after the guard.
+      def call(axn_class, args = {}, ambient_context: NOT_SET)
+        clean = args.reject { |k, _| RESERVED_INPUT_KEYS.include?(k.to_sym) }
+        clean = clean.merge(ambient_context:) unless ambient_context.equal?(NOT_SET)
+
+        Axn::Internal::CurrentCallOptions.with(
+          coerce_input_types: true,                              # always on for tools
+          user_facing_input_errors: @user_facing_input_errors,
+          reject_undeclared_inputs: @reject_undeclared_inputs,
+        ) do
+          axn_class.call(**clean)
+        end
+      end
+
+      def self.input_invalid?(result) = result.exception.is_a?(Axn::InboundValidationError)
+    end
+  end
+end
+```
+
+**Profile knobs / defaults:**
+
+| knob | default | current adapters |
+|---|---|---|
+| coerce inputs | **on for all tools** (not a knob) | on |
+| `user_facing_input_errors` | off | ruby_llm + mcp → **on** |
+| `reject_undeclared_inputs` | off | opt-in per adapter |
+| reserved-key guard (`ambient_context`) | **always on** (untrusted args) | — |
+
+"Configurable per adapter" means each adapter constructs its invoker with the profile it wants; a future adapter (event consumer PRO-2938, OpenAPI PRO-2936) picks its own — an event consumer that *wants* to page on a malformed payload simply does not set `user_facing_input_errors`.
+
+**Reserved-key guard vs normal calls:** direct `ambient_context:` passing stays a valid override for normal `.call` (unchanged — ambient_context.rb resolution honors an explicit kwarg). The guard lives *only* in the invoker: model-supplied args can't set `ambient_context`, forcing the ambient-resolution pipeline for tool calls. The adapter injects its own trusted `ambient_context:` through the `call` kwarg, which is merged *after* the guard strips any smuggled one.
+
+## Downstream migration (separate PRs, adapter repos — not this PR)
+
+Captured here for completeness; each lands in its own repo.
+
+- **axn-ruby_llm** (`tool_adapter.rb`): delete `tool_argument_validator`, `schema_value_matches?`, `json_types_for`, and `JSON_TYPE_PREDICATES` (the shallow pre-check). Build one `Axn::Tools::Invoker.new(user_facing_input_errors: true, reject_undeclared_inputs: …)` in `build_tool_class`; in `execute`, call it and branch:
+  ```ruby
+  result = invoker.call(axn_class, args, **(ambient_context.equal?(NOT_SET) ? {} : { ambient_context: }))
+  next({ error: "Invalid tool arguments: #{result.error}" }) if Axn::Tools::Invoker.input_invalid?(result)
+  next({ error: result.error }) unless result.ok?
+  # … existing payload serialization unchanged
+  ```
+  Keep `normalize_nullable_types` — that is schema wire-shape (Gemini `anyOf` nullability), not argument validation.
+- **axn-mcp** (`invocation.rb`, `serializer.rb`): `Invocation.perform` keeps extracting `server_context` (its transport concern) and passes it as the trusted `ambient_context: { server_context: }` to `invoker.call(axn_class, rest, ambient_context: { server_context: })`; the invoker's guard subsumes the manual `ambient_context` reject in `rest`. Teach `Serializer.result_to_mcp_response` the `input_invalid?` branch so a contract violation maps to a clean "Invalid tool arguments" response rather than the generic error.
+
+## Non-goals / scope guardrails
+
+- Only **inbound** violations reclassify. `fail!`, outbound violations, and genuine `StandardError`s are untouched — they page/behave exactly as today.
+- No global reclassification and no auto-detection of "tool context." Everything is explicit per-call via the invoker.
+- No new `Axn::Result` public methods.
+- No class-level DSL for `user_facing_input_errors` / `reject_undeclared_inputs` (invoker-only for now; additive later).
+- Undeclared-input rejection is top-level only; a nested/subfield unknown-key policy is out of scope.
+
+## Testing
+
+Non-Rails `spec/` (the mechanism has no Rails dependency), mirrored into `spec_rails/` where model-consistency mismatches under `user_facing_input_errors` are involved (models need AR). Cover:
+
+- **Core gates, direct `.call` with each gate set via `CurrentCallOptions.with` (unit-level):**
+  - `user_facing_input_errors`: a type violation, an inclusion violation, a nested-subfield violation, a coerce failure, and a model-consistency mismatch each settle as a non-reported failure (`on_exception` does NOT fire — assert via a config `on_exception` spy), `result.ok?` false, `result.outcome` `failure`, `result.error` the composed per-field sentence, `result.exception` an `InboundValidationError` with `#field_errors` populated.
+  - Gate **off** (default / normal `.call`): identical inputs still fire `on_exception` and surface the generic `result.error` — proving no change to normal semantics.
+  - `coerce_input_types` per-call: a stringly `"42"` for `type: Integer` coerces and passes; a field with explicit `coerce: false` still rejects `"42"` even under the gate (per-field precedence); the class-level setting is unaffected on a direct call without the gate.
+  - `reject_undeclared_inputs`: an undeclared top-level key produces an `"unknown input: <key>"` inbound error (and composes user-facing when 1b is also set); `ambient_context` and declared fields are exempt; nested unknown keys are NOT rejected. Gate off → undeclared keys silently ignored as today.
+  - A `fail!` body, an `OutboundValidationError`, and a raw `StandardError` under all gates still behave as today (`fail!` → failure/no report; outbound → reported bug; StandardError → reported bug); `input_invalid?` is false for each.
+- **`Axn::Tools::Invoker`:** reserved-key guard strips a smuggled `ambient_context:` from `args` while honoring an explicit trusted `ambient_context:` kwarg; profile flags map to the right gates; returns a plain `Axn::Result`; `Invoker.input_invalid?` true only for inbound violations. `coerce_input_types` is on regardless of the wrapped class's own setting; `CurrentCallOptions` is restored after the block (including on exception).
+- **`InboundValidationError#field_errors`:** shape `[{field:, message:}]`, base-level errors surface with `field == :base`, empty when there are no errors.

--- a/lib/axn.rb
+++ b/lib/axn.rb
@@ -17,6 +17,7 @@ require "axn/core"
 require "axn/executor"
 require "axn/reflection"
 require "axn/tools/registry"
+require "axn/tools/invoker"
 
 # Internal utilities
 require "axn/internal/current_call_options"

--- a/lib/axn.rb
+++ b/lib/axn.rb
@@ -19,6 +19,7 @@ require "axn/reflection"
 require "axn/tools/registry"
 
 # Internal utilities
+require "axn/internal/current_call_options"
 require "axn/internal/memoization"
 require "axn/internal/callable"
 require "axn/internal/call_logger"

--- a/lib/axn/core/contract_for_subfields.rb
+++ b/lib/axn/core/contract_for_subfields.rb
@@ -264,7 +264,7 @@ module Axn
       # absent subfield has no value to transform. coerce_value no-ops on a nil/non-String value, so
       # coercion needs no guard.
       def self._apply_read_path_transforms(action, config, value, parent)
-        coerce_input_types = Axn::Configuration.resolve_override_for(action.class, :coerce_input_types)
+        coerce_input_types = Axn::Internal::CurrentCallOptions.coerce_input_types_for(action)
         value = Axn::Reflection::Coercion.coerce_config_value(value, config, coerce_input_types:)
         value = Axn::Internal::FieldConfig.resolve_preprocess(action, config, value) if config.preprocess && !parent.nil?
         value

--- a/lib/axn/exceptions.rb
+++ b/lib/axn/exceptions.rb
@@ -133,6 +133,11 @@ module Axn
     def __present_as(string) = @presentation = string.presence
     def message = @presentation.presence || errors.full_messages.to_sentence
     def to_s = message
+
+    # Structured per-field view of the validation errors, for callers that want to format each
+    # failure individually (e.g. a tool adapter handing per-argument reasons back to a model).
+    # `full_message` so each entry reads standalone; base-level errors surface with field == :base.
+    def field_errors = errors.map { |error| { field: error.attribute, message: error.full_message } }
   end
 
   class InboundValidationError < ValidationError; end

--- a/lib/axn/executor.rb
+++ b/lib/axn/executor.rb
@@ -377,6 +377,10 @@ module Axn
       # clearing the holder so a nested `.call` in the body runs with default semantics. Stash the
       # consumed Options on the action instance (where per-call state lives) so the read-path
       # coercion honors the same gate this executor's validation-message path reads.
+      #
+      # Two copies, deliberately not unified: the action-anchored copy is the only one reachable from
+      # ContractForSubfields' read-path coercion (it has just the action, not this executor), while the
+      # boolean gates below are read only from this executor, off its own copy.
       @__call_options = Internal::CurrentCallOptions.consume
       @action.instance_variable_set(:@__call_options, @__call_options) if @__call_options
 
@@ -978,10 +982,13 @@ module Axn
       memo.fetch(key) { memo[key] = Axn::Core::ContractForSubfields.resolve_parent(@action, config) }
     end
 
-    # Per-call gate readers. `@__call_options` is the consumed CurrentCallOptions (or nil for a
-    # normal call). coerce is tri-state: a nil per-call value falls back to the class/global setting,
-    # so a normal call is unchanged; the tool invoker forces `true`. Resolved through the shared
-    # CurrentCallOptions layer so this validation-message path and the read-path value coercion agree.
+    # Per-call gate readers, anchored differently on purpose. coerce resolves through
+    # CurrentCallOptions.coerce_input_types_for(@action) — the ACTION-anchored copy — because the
+    # read-path value coercion in ContractForSubfields only has the action to read from, so both
+    # readers must resolve off the same anchor to agree; it's tri-state, so a nil per-call value falls
+    # back to the class/global setting (a normal call is unchanged) while the tool invoker forces
+    # `true`. The other two gates are only ever consulted here in the executor, so they read the
+    # executor's own `@__call_options` (nil for a normal call) directly.
     def _coerce_input_types? = Internal::CurrentCallOptions.coerce_input_types_for(@action)
     def _user_facing_input_errors? = @__call_options&.user_facing_input_errors || false
     def _reject_undeclared_inputs? = @__call_options&.reject_undeclared_inputs || false

--- a/lib/axn/executor.rb
+++ b/lib/axn/executor.rb
@@ -663,6 +663,25 @@ module Axn
       Array(override).filter_map { |m| m.presence&.to_s }.presence || own
     end
 
+    # Under reject_undeclared_inputs, every provided top-level wire key that is neither a declared
+    # field/subfield wire root nor the reserved ambient parent becomes a normal inbound error. Top-level
+    # only: keys nested inside a Hash field are not the top-level contract's concern.
+    def _undeclared_input_messages
+      return [] unless _reject_undeclared_inputs?
+
+      (@context.provided_data.keys - _declared_top_level_keys).map { |key| "unknown input: #{key}" }
+    end
+
+    # The set of legitimate top-level wire keys: each inbound config's resolved-path root (top-level
+    # fields fall back to their own field name), plus the reserved always-present ambient parent.
+    def _declared_top_level_keys
+      roots = _inbound_configs.filter_map do |config|
+        path = _resolved_path_for(config)
+        path ? path.wire_path.first : config.field
+      end
+      (roots + [Core::AmbientContext::PARENT]).uniq
+    end
+
     # For id-based (`:find`) `model:` fields, reject contradictory input: a record AND a `<field>_id`
     # that disagree. The RECORD is always extracted raw (never a model lookup): a present record is
     # authoritative, so a defaulted sibling id must not override it into a fabricated conflict — the id
@@ -677,9 +696,6 @@ module Axn
     # carries its own field prefix). Subfield checks are causally suppressed like subfield validation: a
     # failed ancestor means this chain's data is already known-bad, so a consistency mismatch under it
     # is stranding noise.
-    # Placeholder until Task 4 wires undeclared-input rejection; returns [] so base_extras == mismatches.
-    def _undeclared_input_messages = []
-
     def _model_consistency_mismatches(failed_nodes)
       mismatches = []
 

--- a/lib/axn/executor.rb
+++ b/lib/axn/executor.rb
@@ -494,15 +494,19 @@ module Axn
       # top-level config marks its root node, so its whole subtree suppresses through the same rule.
       failures.reject! { |failure| failure.path && _suppressed_by_failed_ancestor?(failure.path, failed_nodes) }
       mismatches = _model_consistency_mismatches(failed_nodes)
-      base_extras = mismatches + _undeclared_input_messages
+      base_extras = mismatches.map(&:message) + _undeclared_input_messages
 
       return if failures.empty? && base_extras.empty?
 
       # Tool-invocation opt-in: treat the WHOLE inbound contract as user-facing for this call —
       # compose every violation (including model-consistency mismatches and unknown-input messages)
       # into one non-reported failure. No new classification; the existing user_facing settling,
-      # applied contract-wide.
-      raise _composed_user_facing_error(failures, base_extras) if _user_facing_input_errors?
+      # applied contract-wide. EXCEPT when any ambient-rooted violation is present: ambient context is
+      # trusted/adapter-supplied, not model input (the DSL already rejects `user_facing:` on ambient
+      # subfields), so an ambient violation must stay dev-facing and report. Per the dominance doctrine,
+      # one such violation makes the WHOLE set settle dev-facing via the path below (an ambient config's
+      # `user_facing` is false, so `_failure_fully_user_facing?` already excludes it).
+      raise _composed_user_facing_error(failures, base_extras) if _user_facing_input_errors? && !_any_ambient_violation?(failures, mismatches)
 
       raise InboundValidationError, _aggregate_errors(failures, base_extras) unless base_extras.empty? && failures.all? { |f| _failure_fully_user_facing?(f) }
 
@@ -513,6 +517,24 @@ module Axn
     end
 
     ContractFailure = Data.define(:config, :path, :errors, :stranded_at)
+
+    # A model-consistency mismatch (record vs. `<field>_id`), carrying its :base message plus whether
+    # the failing config is ambient-rooted — so the tool-invocation gate can keep an ambient mismatch
+    # dev-facing (see `_any_ambient_violation?`) without re-running the side-effecting resolution.
+    ConsistencyMismatch = Data.define(:message, :ambient)
+
+    # Whether any unsuppressed inbound violation roots at ambient context (trusted/adapter-supplied,
+    # never model input). Used only by the tool-invocation gate to refuse the contract-wide user-facing
+    # compose when an ambient violation is present, so the dev-facing settle path reports it instead.
+    def _any_ambient_violation?(failures, mismatches)
+      failures.any? { |failure| _ambient_config?(failure.config) } || mismatches.any?(&:ambient)
+    end
+
+    # A config is ambient-rooted when it's a subfield whose `on:` chain roots at :ambient_context.
+    # Reuses the canonical class-level predicate; a top-level field (`on: nil`) is never ambient.
+    def _ambient_config?(config)
+      config.subfield? && @action_class.send(:_on_roots_at_ambient?, config.on)
+    end
 
     # Every inbound config's errors — top-level fields and subfields through the one collector —
     # gathered in declaration order with no early exit: settling needs the complete set (both to
@@ -725,7 +747,7 @@ module Axn
         record = Axn::Core::ContractForSubfields._memoized_raw_extract(@action, config, @context.provided_data)
         raw_id = _consistency_id_for(config)
         msg = _record_id_mismatch(field: config.field, record:, raw_id:)
-        mismatches << msg if msg
+        mismatches << ConsistencyMismatch.new(message: msg, ambient: false) if msg
       end
 
       @action_class.send(:subfield_configs).each do |config|
@@ -737,7 +759,7 @@ module Axn
         record = Axn::Core::ContractForSubfields._memoized_raw_extract(@action, config, source)
         raw_id = _consistency_id_for(config)
         msg = _record_id_mismatch(field: config.field, record:, raw_id:)
-        mismatches << msg if msg
+        mismatches << ConsistencyMismatch.new(message: msg, ambient: _ambient_config?(config)) if msg
       end
 
       mismatches

--- a/lib/axn/executor.rb
+++ b/lib/axn/executor.rb
@@ -490,10 +490,17 @@ module Axn
       # top-level config marks its root node, so its whole subtree suppresses through the same rule.
       failures.reject! { |failure| failure.path && _suppressed_by_failed_ancestor?(failure.path, failed_nodes) }
       mismatches = _model_consistency_mismatches(failed_nodes)
+      base_extras = mismatches + _undeclared_input_messages
 
-      return if failures.empty? && mismatches.empty?
+      return if failures.empty? && base_extras.empty?
 
-      raise InboundValidationError, _aggregate_errors(failures, mismatches) unless mismatches.empty? && failures.all? { |f| _failure_fully_user_facing?(f) }
+      # Tool-invocation opt-in: treat the WHOLE inbound contract as user-facing for this call —
+      # compose every violation (including model-consistency mismatches and unknown-input messages)
+      # into one non-reported failure. No new classification; the existing user_facing settling,
+      # applied contract-wide.
+      raise _composed_user_facing_error(failures, base_extras) if _user_facing_input_errors?
+
+      raise InboundValidationError, _aggregate_errors(failures, base_extras) unless base_extras.empty? && failures.all? { |f| _failure_fully_user_facing?(f) }
 
       # Resolve the user-facing message — invoking any Symbol/Proc handler — only now, once we know
       # this is the exception we actually raise (the dominance check above didn't pre-empt it), so a
@@ -585,9 +592,12 @@ module Axn
     # unit — each failing config's own `user_facing:` and each shape-member's own tagged intent — one
     # uniform path for every depth. Parts are de-duplicated so a String/Symbol member override on an
     # Array shape surfaces once rather than repeating per failing element.
-    def _composed_user_facing_error(failures)
-      parts = failures.flat_map { |failure| _user_facing_parts(failure) }
-      InboundValidationError.new(_aggregate_errors(failures, []),
+    # base_extras are :base-level message strings (model-consistency mismatches and, under
+    # reject_undeclared_inputs, unknown-input messages) that compose into the user-facing message and
+    # aggregate onto :base. Empty by default, so the per-field-declared path is unchanged.
+    def _composed_user_facing_error(failures, base_extras = [])
+      parts = failures.flat_map { |failure| _user_facing_parts(failure) } + base_extras
+      InboundValidationError.new(_aggregate_errors(failures, base_extras),
                                  user_facing: true, user_facing_message: parts.uniq.to_sentence)
     end
 
@@ -667,6 +677,9 @@ module Axn
     # carries its own field prefix). Subfield checks are causally suppressed like subfield validation: a
     # failed ancestor means this chain's data is already known-bad, so a consistency mismatch under it
     # is stranding noise.
+    # Placeholder until Task 4 wires undeclared-input rejection; returns [] so base_extras == mismatches.
+    def _undeclared_input_messages = []
+
     def _model_consistency_mismatches(failed_nodes)
       mismatches = []
 

--- a/lib/axn/executor.rb
+++ b/lib/axn/executor.rb
@@ -373,6 +373,13 @@ module Axn
     # =========================================================================
 
     def with_contract(&block)
+      # Take sole ownership of any per-call gates set by the caller (e.g. Axn::Tools::Invoker),
+      # clearing the holder so a nested `.call` in the body runs with default semantics. Stash the
+      # consumed Options on the action instance (where per-call state lives) so the read-path
+      # coercion honors the same gate this executor's validation-message path reads.
+      @__call_options = Internal::CurrentCallOptions.consume
+      @action.instance_variable_set(:@__call_options, @__call_options) if @__call_options
+
       # A pre-pipeline read — a hook/preprocess touching a reader (which may consult a sibling's
       # value-level default via resolve_model_via_id) — can populate both
       # ContractForSubfields' @__resolve_value_cache AND a reader's own memo before inbound validation
@@ -502,7 +509,7 @@ module Axn
     # validates against the inbound facade (which resolves model records and reads by wire key); a
     # subfield against its canonically-resolved parent, with its reader supplied for model resolution.
     def _collect_contract_failures
-      coerce_input_types = Axn::Configuration.resolve_override_for(@action_class, :coerce_input_types)
+      coerce_input_types = _coerce_input_types?
 
       _inbound_configs.filter_map do |config|
         errors = Axn::Validation::Fields.collect_errors(
@@ -928,5 +935,13 @@ module Axn
       key = [config.on.to_s, config.method_call]
       memo.fetch(key) { memo[key] = Axn::Core::ContractForSubfields.resolve_parent(@action, config) }
     end
+
+    # Per-call gate readers. `@__call_options` is the consumed CurrentCallOptions (or nil for a
+    # normal call). coerce is tri-state: a nil per-call value falls back to the class/global setting,
+    # so a normal call is unchanged; the tool invoker forces `true`. Resolved through the shared
+    # CurrentCallOptions layer so this validation-message path and the read-path value coercion agree.
+    def _coerce_input_types? = Internal::CurrentCallOptions.coerce_input_types_for(@action)
+    def _user_facing_input_errors? = @__call_options&.user_facing_input_errors || false
+    def _reject_undeclared_inputs? = @__call_options&.reject_undeclared_inputs || false
   end
 end

--- a/lib/axn/executor.rb
+++ b/lib/axn/executor.rb
@@ -679,7 +679,20 @@ module Axn
         path = _resolved_path_for(config)
         path ? path.wire_path.first : config.field
       end
-      (roots + [Core::AmbientContext::PARENT]).uniq
+      (roots + _model_id_top_level_keys + [Core::AmbientContext::PARENT]).uniq
+    end
+
+    # Every top-level `model:` field derives a `<field>_id` reader (Contract._define_model_id_reader)
+    # that the resolver consumes as its lookup token (FieldResolvers::Model#derive_value) whenever no
+    # record is provided, so a caller may legitimately supply `<field>_id` at the top level even with
+    # no explicit sibling declared. Exempt that implicit key from the undeclared-input gate. Same
+    # `<field>_id` convention (any config carrying a `model:`, not just id-based finders — a custom
+    # finder reads its token off the same key) Contract keys off for sensitive-alias filtering. Only
+    # top-level configs contribute: a subfield model's id key is nested, not a top-level provided key.
+    def _model_id_top_level_keys
+      @action_class.send(:internal_field_configs).filter_map do |config|
+        Internal::FieldConfig.model_id_key(config.field) if config.validations[:model]
+      end
     end
 
     # For id-based (`:find`) `model:` fields, reject contradictory input: a record AND a `<field>_id`

--- a/lib/axn/executor.rb
+++ b/lib/axn/executor.rb
@@ -700,8 +700,12 @@ module Axn
 
     # The set of legitimate top-level wire keys: each inbound config's resolved-path root (top-level
     # fields fall back to their own field name), plus the reserved always-present ambient parent.
+    # Ambient subfields live in a separate ambient-scoped tree (no `_resolved_path_for`), so their leaf
+    # name is never a top-level input — only the reserved ambient parent exempts them.
     def _declared_top_level_keys
       roots = _inbound_configs.filter_map do |config|
+        next if _ambient_config?(config)
+
         path = _resolved_path_for(config)
         path ? path.wire_path.first : config.field
       end

--- a/lib/axn/internal/current_call_options.rb
+++ b/lib/axn/internal/current_call_options.rb
@@ -28,6 +28,25 @@ module Axn
         # Read the current options and clear the holder, so the reading action takes sole ownership
         # and nested sub-actions do not inherit the gates.
         def consume = current.tap { self.current = nil }
+
+        # The Options in force for `action`'s current call, or nil for a normal call. The executor
+        # stashes the consumed Options on the action at the top of its contract phase (per-call state
+        # lives on the action instance), so the read-path coercion can reach the same gate the
+        # executor's validation-message path reads.
+        def for_action(action)
+          return nil unless action.instance_variable_defined?(:@__call_options)
+
+          action.instance_variable_get(:@__call_options)
+        end
+
+        # The effective coerce_input_types for `action`'s current call: a non-nil per-call gate wins,
+        # else the class/global setting — so a normal call resolves exactly as before. Single-sourced
+        # so the executor's validation-message path and the read-path value coercion
+        # (ContractForSubfields) decide identically.
+        def coerce_input_types_for(action)
+          per_call = for_action(action)&.coerce_input_types
+          per_call.nil? ? Axn::Configuration.resolve_override_for(action.class, :coerce_input_types) : per_call
+        end
       end
     end
   end

--- a/lib/axn/internal/current_call_options.rb
+++ b/lib/axn/internal/current_call_options.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Axn
+  module Internal
+    # Per-call tuning gates set by a caller (today only Axn::Tools::Invoker) and read once by the
+    # executor. Scoped via IsolatedExecutionState (same pattern as Async::CurrentRetryContext) so
+    # nothing rides on `.call`'s kwargs. The executor `consume`s (reads + clears) at the top of its
+    # contract phase, so the gates apply to exactly the wrapped action and a nested `.call` in its
+    # body sees a cleared holder and runs with default semantics.
+    module CurrentCallOptions
+      Options = Data.define(:coerce_input_types, :user_facing_input_errors, :reject_undeclared_inputs)
+
+      class << self
+        def current = ActiveSupport::IsolatedExecutionState[:_axn_call_options]
+
+        def current=(value)
+          ActiveSupport::IsolatedExecutionState[:_axn_call_options] = value
+        end
+
+        def with(coerce_input_types: nil, user_facing_input_errors: false, reject_undeclared_inputs: false)
+          previous = current
+          self.current = Options.new(coerce_input_types:, user_facing_input_errors:, reject_undeclared_inputs:)
+          yield
+        ensure
+          self.current = previous
+        end
+
+        # Read the current options and clear the holder, so the reading action takes sole ownership
+        # and nested sub-actions do not inherit the gates.
+        def consume = current.tap { self.current = nil }
+      end
+    end
+  end
+end

--- a/lib/axn/tools/invoker.rb
+++ b/lib/axn/tools/invoker.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Axn
+  module Tools
+    # The sanctioned entry point for running an Axn AS A TOOL. Holds an adapter's chosen profile and
+    # runs `.call` under the matching per-call gates (Axn::Internal::CurrentCallOptions), returning a
+    # plain Axn::Result so an adapter's existing result-mapping is unchanged. Coercion is always on
+    # for tools (the trusted-JSON boundary wants it, and a field's own `coerce:` still wins); the
+    # user-facing surfacing and undeclared-input rejection are per-adapter opt-ins. Detection of an
+    # input-contract failure rides on the returned result's exception (`input_invalid?`), not on any
+    # new Axn::Result method.
+    class Invoker
+      NOT_SET = Object.new.freeze
+
+      # axn framework-reserved input keys that untrusted (model-supplied) args may not set. Currently
+      # only :ambient_context — direct passing is a valid override for a normal `.call`, but a tool's
+      # args come from the model, so the invoker forces the ambient-resolution pipeline and lets the
+      # adapter inject its own trusted context. NOT :server_context — that is an mcp transport concept
+      # the mcp adapter extracts itself and passes in as the trusted ambient_context.
+      RESERVED_INPUT_KEYS = %i[ambient_context].freeze
+
+      def initialize(user_facing_input_errors: false, reject_undeclared_inputs: false)
+        @user_facing_input_errors = user_facing_input_errors
+        @reject_undeclared_inputs = reject_undeclared_inputs
+      end
+
+      # args: the untrusted, model-supplied argument hash.
+      # ambient_context: the adapter's OWN trusted ambient context (optional), merged after the guard.
+      def call(axn_class, args = {}, ambient_context: NOT_SET)
+        clean = args.reject { |key, _| RESERVED_INPUT_KEYS.include?(key.to_sym) }
+        clean = clean.merge(ambient_context:) unless ambient_context.equal?(NOT_SET)
+
+        Axn::Internal::CurrentCallOptions.with(
+          coerce_input_types: true,
+          user_facing_input_errors: @user_facing_input_errors,
+          reject_undeclared_inputs: @reject_undeclared_inputs,
+        ) do
+          axn_class.call(**clean)
+        end
+      end
+
+      # Whether a returned result failed on an inbound contract violation (as opposed to a `fail!`,
+      # an outbound violation, or a genuine exception). Mode-independent — true regardless of whether
+      # the violation was reported or surfaced as user-facing.
+      def self.input_invalid?(result) = result.exception.is_a?(Axn::InboundValidationError)
+    end
+  end
+end

--- a/lib/axn/tools/invoker.rb
+++ b/lib/axn/tools/invoker.rb
@@ -39,10 +39,14 @@ module Axn
         end
       end
 
-      # Whether a returned result failed on an inbound contract violation (as opposed to a `fail!`,
-      # an outbound violation, or a genuine exception). Mode-independent — true regardless of whether
-      # the violation was reported or surfaced as user-facing.
-      def self.input_invalid?(result) = result.exception.is_a?(Axn::InboundValidationError)
+      # Whether a returned result failed on an inbound contract violation that was surfaced as a
+      # correctable CALLER (model) error — i.e. an inbound violation settled user-facing under
+      # `user_facing_input_errors`. A dev-facing inbound failure (a normal reported bug, or an
+      # ambient-context violation, which stays dev-facing because ambient context is trusted/
+      # adapter-supplied) already paged `on_exception` and is NOT flagged here, so the adapter returns
+      # its generic error rather than telling the model "Invalid tool arguments" for an infra bug.
+      # False for a `fail!`, an outbound violation, or any other raised exception.
+      def self.input_invalid?(result) = Axn::ValidationError.user_facing?(result.exception)
     end
   end
 end

--- a/spec/axn/core/tool_invocation_gates_spec.rb
+++ b/spec/axn/core/tool_invocation_gates_spec.rb
@@ -118,6 +118,69 @@ RSpec.describe "tool invocation gates: user_facing_input_errors" do
   end
 end
 
+RSpec.describe "tool invocation gates: user_facing_input_errors with ambient context" do
+  def invoke(klass, **args)
+    Axn::Internal::CurrentCallOptions.with(user_facing_input_errors: true) { klass.call(**args) }
+  end
+
+  let(:ambient_action) do
+    Class.new do
+      include Axn
+      expects :current_user, on: :ambient_context, type: String
+      def call; end
+    end
+  end
+
+  it "keeps a MISSING ambient value dev-facing (reports) even under the gate" do
+    expect(Axn.config).to receive(:on_exception).at_least(:once)
+    result = invoke(ambient_action) # no ambient_context supplied → current_user unresolved
+    expect(result).not_to be_ok
+    expect(result.outcome).to eq("exception")
+    expect(result.exception).to be_a(Axn::InboundValidationError)
+    expect(Axn::ValidationError.user_facing?(result.exception)).to be(false)
+    expect(result.error).not_to match(/current_user/i) # generic headline, not the ambient field detail
+  end
+
+  it "keeps a MALFORMED ambient value dev-facing (reports) even under the gate" do
+    expect(Axn.config).to receive(:on_exception).at_least(:once)
+    result = invoke(ambient_action, ambient_context: { current_user: 123 }) # wrong type, adapter-supplied
+    expect(result).not_to be_ok
+    expect(result.outcome).to eq("exception")
+    expect(Axn::ValidationError.user_facing?(result.exception)).to be(false)
+  end
+
+  it "reports the WHOLE set dev-facing when an ambient failure co-occurs with a model-supplied one" do
+    expect(Axn.config).to receive(:on_exception).at_least(:once)
+    mixed = Class.new do
+      include Axn
+      expects :name, type: String
+      expects :current_user, on: :ambient_context, type: String
+      def call; end
+    end
+    result = invoke(mixed, name: 123) # bad model-supplied name + missing ambient current_user
+    expect(result).not_to be_ok
+    expect(result.outcome).to eq("exception")
+    expect(result.exception).to be_a(Axn::InboundValidationError)
+    expect(Axn::ValidationError.user_facing?(result.exception)).to be(false)
+  end
+
+  it "still composes user-facing when ONLY model-supplied fields fail (regression)" do
+    expect(Axn.config).not_to receive(:on_exception)
+    supplied = Class.new do
+      include Axn
+      expects :name, type: String
+      expects :current_user, on: :ambient_context, type: String
+      def call; end
+    end
+    # ambient current_user is validly supplied; only the model-supplied name is bad
+    result = invoke(supplied, name: 123, ambient_context: { current_user: "trusted" })
+    expect(result).not_to be_ok
+    expect(result.outcome).to eq("failure")
+    expect(Axn::ValidationError.user_facing?(result.exception)).to be(true)
+    expect(result.error).to match(/name/i)
+  end
+end
+
 RSpec.describe "tool invocation gates: reject_undeclared_inputs" do
   let(:action) do
     Class.new do

--- a/spec/axn/core/tool_invocation_gates_spec.rb
+++ b/spec/axn/core/tool_invocation_gates_spec.rb
@@ -171,4 +171,52 @@ RSpec.describe "tool invocation gates: reject_undeclared_inputs" do
     end
     expect(result.outcome).to eq("exception")
   end
+
+  describe "implicit <field>_id for a top-level model: field with no explicit sibling" do
+    let(:co_class) do
+      Class.new do
+        def self.name = "Co"
+        attr_reader :id
+
+        def initialize(id) = @id = id
+        def self.find(id) = new(id)
+      end
+    end
+
+    it "does NOT reject <field>_id (default finder) supplied at the top level" do
+      klass = co_class
+      model_action = build_axn do
+        expects :company, model: { klass:, finder: :find }
+        exposes :cid
+
+        def call = expose(cid: company_id)
+      end
+
+      result = Axn::Internal::CurrentCallOptions.with(reject_undeclared_inputs: true, user_facing_input_errors: true) do
+        model_action.call(company_id: 5)
+      end
+      expect(result).to be_ok
+      expect(result.cid).to eq(5)
+    end
+
+    it "does NOT reject <field>_id (custom finder) supplied at the top level" do
+      co = co_class
+      dir = Class.new do
+        define_singleton_method(:find_by_token) { |tok| tok == "abc" ? co.new(42) : nil }
+      end
+      klass = co_class
+      model_action = build_axn do
+        expects :company, model: { klass:, finder: dir.method(:find_by_token) }
+        exposes :cid
+
+        def call = expose(cid: company_id)
+      end
+
+      result = Axn::Internal::CurrentCallOptions.with(reject_undeclared_inputs: true, user_facing_input_errors: true) do
+        model_action.call(company_id: "abc")
+      end
+      expect(result).to be_ok
+      expect(result.cid).to eq(42)
+    end
+  end
 end

--- a/spec/axn/core/tool_invocation_gates_spec.rb
+++ b/spec/axn/core/tool_invocation_gates_spec.rb
@@ -55,3 +55,65 @@ RSpec.describe "tool invocation gates: coerce_input_types" do
     expect(result.__action__.inner_result).not_to be_ok # nested "7" was NOT coerced
   end
 end
+
+RSpec.describe "tool invocation gates: user_facing_input_errors" do
+  let(:action) do
+    Class.new do
+      include Axn
+      expects :name, type: String
+      expects :status, type: String, inclusion: { in: %w[active closed] }
+      def call; end
+    end
+  end
+
+  def invoke(**args)
+    Axn::Internal::CurrentCallOptions.with(user_facing_input_errors: true) { action.call(**args) }
+  end
+
+  it "settles a type violation as a non-reported user-facing failure" do
+    expect(Axn.config).not_to receive(:on_exception)
+    result = invoke(name: 123, status: "active")
+    expect(result).not_to be_ok
+    expect(result.outcome).to eq("failure")
+    expect(result.exception).to be_a(Axn::InboundValidationError)
+    expect(result.error).to match(/name/i)
+  end
+
+  it "surfaces per-field detail for an inclusion (enum) violation" do
+    result = invoke(name: "ok", status: "nope")
+    expect(result.error).to match(/not included/i)
+  end
+
+  it "composes multiple violations into one message" do
+    result = invoke(name: 123, status: "nope")
+    expect(result.error).to match(/name/i).and match(/status/i)
+  end
+
+  it "still REPORTS the same inputs on a normal call (no gate)" do
+    expect(Axn.config).to receive(:on_exception).at_least(:once)
+    result = action.call(name: 123, status: "active")
+    expect(result).not_to be_ok
+    expect(result.outcome).to eq("exception")
+  end
+
+  it "does NOT reclassify a fail! in the body" do
+    failing = Class.new do
+      include Axn
+      def call = fail!("nope")
+    end
+    result = Axn::Internal::CurrentCallOptions.with(user_facing_input_errors: true) { failing.call }
+    expect(result.outcome).to eq("failure")
+    expect(result.exception).not_to be_a(Axn::InboundValidationError)
+    expect(result.error).to eq("nope")
+  end
+
+  it "does NOT reclassify a genuine StandardError in the body (still reports)" do
+    expect(Axn.config).to receive(:on_exception).at_least(:once)
+    boom = Class.new do
+      include Axn
+      def call = raise "kaboom"
+    end
+    result = Axn::Internal::CurrentCallOptions.with(user_facing_input_errors: true) { boom.call }
+    expect(result.outcome).to eq("exception")
+  end
+end

--- a/spec/axn/core/tool_invocation_gates_spec.rb
+++ b/spec/axn/core/tool_invocation_gates_spec.rb
@@ -235,6 +235,40 @@ RSpec.describe "tool invocation gates: reject_undeclared_inputs" do
     expect(result.outcome).to eq("exception")
   end
 
+  describe "ambient subfields never enter the top-level allow-list" do
+    let(:ambient_action) do
+      Class.new do
+        include Axn
+        expects :name, type: String
+        expects :current_user, on: :ambient_context, type: String
+        def call; end
+      end
+    end
+
+    def invoke(klass, **args)
+      Axn::Internal::CurrentCallOptions.with(reject_undeclared_inputs: true, user_facing_input_errors: true) do
+        klass.call(**args)
+      end
+    end
+
+    it "rejects a model-supplied top-level key matching the ambient leaf name" do
+      result = invoke(ambient_action, name: "ok", current_user: "evil", ambient_context: { current_user: "trusted" })
+      expect(result).not_to be_ok
+      expect(result.exception).to be_a(Axn::InboundValidationError)
+      expect(result.error).to include("unknown input: current_user")
+    end
+
+    it "accepts the ambient value supplied the trusted way via ambient_context" do
+      result = invoke(ambient_action, name: "ok", ambient_context: { current_user: "trusted" })
+      expect(result).to be_ok
+    end
+
+    it "still accepts a normal declared top-level field alongside a valid ambient value" do
+      result = invoke(ambient_action, name: "ok", ambient_context: { current_user: "trusted" })
+      expect(result).to be_ok
+    end
+  end
+
   describe "implicit <field>_id for a top-level model: field with no explicit sibling" do
     let(:co_class) do
       Class.new do

--- a/spec/axn/core/tool_invocation_gates_spec.rb
+++ b/spec/axn/core/tool_invocation_gates_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "tool invocation gates: coerce_input_types" do
+  let(:action) do
+    Class.new do
+      include Axn
+      expects :age, type: Integer
+      expects :count, type: { klass: Integer, coerce: false }
+      exposes :age, :count
+      def call
+        expose(age:, count:)
+      end
+    end
+  end
+
+  it "coerces a wire string when the per-call gate is set (field lacks explicit coerce:)" do
+    result = Axn::Internal::CurrentCallOptions.with(coerce_input_types: true) do
+      action.call(age: "42", count: 5)
+    end
+    expect(result).to be_ok
+    expect(result.age).to eq(42)
+  end
+
+  it "honors a field-level `coerce: false` even under the per-call gate" do
+    result = Axn::Internal::CurrentCallOptions.with(coerce_input_types: true) do
+      action.call(age: "42", count: "5")
+    end
+    expect(result).not_to be_ok
+    expect(result.exception).to be_a(Axn::InboundValidationError)
+  end
+
+  it "does not coerce on a normal call with no gate set" do
+    result = action.call(age: "42", count: 5)
+    expect(result).not_to be_ok
+  end
+
+  it "does not leak the gate into a nested sub-action" do
+    inner = Class.new do
+      include Axn
+      expects :n, type: Integer
+      def call; end
+    end
+    outer = Class.new do
+      include Axn
+      expects :age, type: Integer
+      define_method(:call) { @inner_result = inner.call(n: "7") }
+      attr_reader :inner_result
+    end
+    result = Axn::Internal::CurrentCallOptions.with(coerce_input_types: true) do
+      outer.call(age: "1")
+    end
+    expect(result).to be_ok
+    expect(result.__action__.inner_result).not_to be_ok # nested "7" was NOT coerced
+  end
+end

--- a/spec/axn/core/tool_invocation_gates_spec.rb
+++ b/spec/axn/core/tool_invocation_gates_spec.rb
@@ -117,3 +117,58 @@ RSpec.describe "tool invocation gates: user_facing_input_errors" do
     expect(result.outcome).to eq("exception")
   end
 end
+
+RSpec.describe "tool invocation gates: reject_undeclared_inputs" do
+  let(:action) do
+    Class.new do
+      include Axn
+      expects :name, type: String
+      expects :address, type: Hash
+      expects :city, on: :address, type: String # subfield: :address is a legitimate top-level wire root
+      def call; end
+    end
+  end
+
+  it "rejects an undeclared top-level key as an inbound error" do
+    result = Axn::Internal::CurrentCallOptions.with(reject_undeclared_inputs: true, user_facing_input_errors: true) do
+      action.call(name: "ok", address: { city: "NYC" }, bogus: 1)
+    end
+    expect(result).not_to be_ok
+    expect(result.exception).to be_a(Axn::InboundValidationError)
+    expect(result.error).to include("unknown input: bogus")
+  end
+
+  it "exempts declared fields and subfield wire roots" do
+    result = Axn::Internal::CurrentCallOptions.with(reject_undeclared_inputs: true, user_facing_input_errors: true) do
+      action.call(name: "ok", address: { city: "NYC" })
+    end
+    expect(result).to be_ok
+  end
+
+  it "exempts the reserved ambient_context key" do
+    result = Axn::Internal::CurrentCallOptions.with(reject_undeclared_inputs: true, user_facing_input_errors: true) do
+      action.call(name: "ok", address: { city: "NYC" }, ambient_context: {})
+    end
+    expect(result).to be_ok
+  end
+
+  it "does NOT reject undeclared keys NESTED inside a hash field" do
+    result = Axn::Internal::CurrentCallOptions.with(reject_undeclared_inputs: true, user_facing_input_errors: true) do
+      action.call(name: "ok", address: { city: "NYC", zip: "10001" })
+    end
+    expect(result).to be_ok
+  end
+
+  it "silently ignores undeclared keys when the gate is off" do
+    result = action.call(name: "ok", address: { city: "NYC" }, bogus: 1)
+    expect(result).to be_ok
+  end
+
+  it "surfaces an undeclared key as a dev-facing reported bug when user_facing is off but reject is on" do
+    expect(Axn.config).to receive(:on_exception).at_least(:once)
+    result = Axn::Internal::CurrentCallOptions.with(reject_undeclared_inputs: true) do
+      action.call(name: "ok", address: { city: "NYC" }, bogus: 1)
+    end
+    expect(result.outcome).to eq("exception")
+  end
+end

--- a/spec/axn/exceptions_field_errors_spec.rb
+++ b/spec/axn/exceptions_field_errors_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Axn::InboundValidationError do
+  def errors_with(&block)
+    e = ActiveModel::Errors.new(Axn::Validation::Aggregate.new)
+    block.call(e)
+    e
+  end
+
+  it "maps each error to {field:, message:} using the full message" do
+    errors = errors_with { |e| e.add(:name, "is not a String") }
+    exc = described_class.new(errors)
+    expect(exc.field_errors).to eq([{ field: :name, message: "Name is not a String" }])
+  end
+
+  it "surfaces base-level errors with field == :base" do
+    errors = errors_with { |e| e.add(:base, "unknown input: bogus") }
+    exc = described_class.new(errors)
+    expect(exc.field_errors).to eq([{ field: :base, message: "unknown input: bogus" }])
+  end
+
+  it "is empty when there are no errors" do
+    exc = described_class.new(errors_with { |_e| })
+    expect(exc.field_errors).to eq([])
+  end
+end

--- a/spec/axn/internal/current_call_options_spec.rb
+++ b/spec/axn/internal/current_call_options_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Axn::Internal::CurrentCallOptions do
+  after { described_class.current = nil }
+
+  it "defaults to no current options" do
+    expect(described_class.current).to be_nil
+  end
+
+  it "sets options within a `with` block and restores afterward" do
+    described_class.with(user_facing_input_errors: true) do
+      expect(described_class.current.user_facing_input_errors).to be(true)
+      expect(described_class.current.coerce_input_types).to be_nil
+      expect(described_class.current.reject_undeclared_inputs).to be(false)
+    end
+    expect(described_class.current).to be_nil
+  end
+
+  it "restores the prior value even when the block raises" do
+    expect do
+      described_class.with(coerce_input_types: true) { raise "boom" }
+    end.to raise_error("boom")
+    expect(described_class.current).to be_nil
+  end
+
+  it "consume returns the current options and clears the holder" do
+    described_class.with(reject_undeclared_inputs: true) do
+      consumed = described_class.consume
+      expect(consumed.reject_undeclared_inputs).to be(true)
+      expect(described_class.current).to be_nil
+    end
+  end
+
+  it "consume returns nil when nothing is set" do
+    expect(described_class.consume).to be_nil
+  end
+end

--- a/spec/axn/tools/invoker_spec.rb
+++ b/spec/axn/tools/invoker_spec.rb
@@ -93,6 +93,37 @@ RSpec.describe Axn::Tools::Invoker do
     expect(result.tenant).to eq("trusted")
   end
 
+  it "rejects a model-supplied top-level key matching an ambient leaf name under reject_undeclared_inputs" do
+    ambient_action = Class.new do
+      include Axn
+      expects :name, type: String
+      expects :current_user, on: :ambient_context, type: String
+      def call; end
+    end
+    invoker = described_class.new(reject_undeclared_inputs: true, user_facing_input_errors: true)
+    result = invoker.call(
+      ambient_action,
+      { name: "ok", current_user: "evil" }, # hallucinated top-level key mirroring the ambient leaf
+      ambient_context: { current_user: "trusted" },
+    )
+    expect(result).not_to be_ok
+    expect(result.exception).to be_a(Axn::InboundValidationError)
+    expect(result.error).to include("unknown input: current_user")
+    expect(described_class.input_invalid?(result)).to be(true)
+  end
+
+  it "accepts the trusted ambient value alongside a declared field under reject_undeclared_inputs" do
+    ambient_action = Class.new do
+      include Axn
+      expects :name, type: String
+      expects :current_user, on: :ambient_context, type: String
+      def call; end
+    end
+    invoker = described_class.new(reject_undeclared_inputs: true, user_facing_input_errors: true)
+    result = invoker.call(ambient_action, { name: "ok" }, ambient_context: { current_user: "trusted" })
+    expect(result).to be_ok
+  end
+
   it "keeps a MISSING ambient value dev-facing under user_facing_input_errors (input_invalid? false)" do
     expect(Axn.config).to receive(:on_exception).at_least(:once)
     ambient_action = Class.new do

--- a/spec/axn/tools/invoker_spec.rb
+++ b/spec/axn/tools/invoker_spec.rb
@@ -34,9 +34,19 @@ RSpec.describe Axn::Tools::Invoker do
     expect(result.error).to match(/name/i)
   end
 
-  it "input_invalid? is false for a fail! / success" do
+  it "input_invalid? is false for a success" do
     ok = described_class.new.call(action, { name: "ada", age: 36 })
     expect(described_class.input_invalid?(ok)).to be(false)
+  end
+
+  it "input_invalid? is false for a fail!" do
+    failing = Class.new do
+      include Axn
+      def call = fail!("nope")
+    end
+    result = described_class.new.call(failing, {})
+    expect(result).not_to be_ok
+    expect(described_class.input_invalid?(result)).to be(false)
   end
 
   it "strips a model-supplied ambient_context from untrusted args" do
@@ -47,6 +57,23 @@ RSpec.describe Axn::Tools::Invoker do
       attr_reader :seen
     end
     result = described_class.new.call(sensing, { x: 1, ambient_context: { tenant: "evil" } })
+    expect(result.__action__.seen).to eq({})
+  end
+
+  it "strips a model-supplied ambient_context passed as a STRING key from untrusted args" do
+    # A declared ambient subfield is required here: with none declared, `ambient_context` short-circuits
+    # to {} unconditionally (Bug Z1), which would pass this assertion even if the strip predicate were
+    # broken to symbol-only comparison. Declaring :tenant (optional, so a stripped/absent value doesn't
+    # fail validation before `call` runs) forces real resolution against `provided_data`, so a leaked
+    # string-keyed "ambient_context" surfaces as `{ tenant: "evil" }` instead of `{}`.
+    sensing = Class.new do
+      include Axn
+      expects :tenant, on: :ambient_context, type: String, optional: true
+      define_method(:call) { @seen = ambient_context }
+      attr_reader :seen
+    end
+    result = described_class.new.call(sensing, { "ambient_context" => { tenant: "evil" } })
+    expect(result).to be_ok
     expect(result.__action__.seen).to eq({})
   end
 

--- a/spec/axn/tools/invoker_spec.rb
+++ b/spec/axn/tools/invoker_spec.rb
@@ -93,6 +93,48 @@ RSpec.describe Axn::Tools::Invoker do
     expect(result.tenant).to eq("trusted")
   end
 
+  it "keeps a MISSING ambient value dev-facing under user_facing_input_errors (input_invalid? false)" do
+    expect(Axn.config).to receive(:on_exception).at_least(:once)
+    ambient_action = Class.new do
+      include Axn
+      expects :current_user, on: :ambient_context, type: String
+      def call; end
+    end
+    invoker = described_class.new(user_facing_input_errors: true)
+    result = invoker.call(ambient_action, {}) # adapter injects NO ambient_context
+    expect(result).not_to be_ok
+    expect(result.exception).to be_a(Axn::InboundValidationError)
+    expect(Axn::ValidationError.user_facing?(result.exception)).to be(false)
+    expect(described_class.input_invalid?(result)).to be(false)
+  end
+
+  it "keeps a MALFORMED adapter-supplied ambient value dev-facing (input_invalid? false)" do
+    expect(Axn.config).to receive(:on_exception).at_least(:once)
+    ambient_action = Class.new do
+      include Axn
+      expects :current_user, on: :ambient_context, type: String
+      def call; end
+    end
+    invoker = described_class.new(user_facing_input_errors: true)
+    result = invoker.call(ambient_action, {}, ambient_context: { current_user: 123 })
+    expect(result).not_to be_ok
+    expect(described_class.input_invalid?(result)).to be(false)
+  end
+
+  it "reports the whole set (input_invalid? false) when ambient and model-supplied fail together" do
+    expect(Axn.config).to receive(:on_exception).at_least(:once)
+    mixed = Class.new do
+      include Axn
+      expects :name, type: String
+      expects :current_user, on: :ambient_context, type: String
+      def call; end
+    end
+    invoker = described_class.new(user_facing_input_errors: true)
+    result = invoker.call(mixed, { name: 123 })
+    expect(result).not_to be_ok
+    expect(described_class.input_invalid?(result)).to be(false)
+  end
+
   it "clears CurrentCallOptions after the call" do
     described_class.new(user_facing_input_errors: true).call(action, { name: "ada", age: 36 })
     expect(Axn::Internal::CurrentCallOptions.current).to be_nil

--- a/spec/axn/tools/invoker_spec.rb
+++ b/spec/axn/tools/invoker_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Axn::Tools::Invoker do
+  let(:action) do
+    Class.new do
+      include Axn
+      expects :name, type: String
+      expects :age, type: Integer
+      exposes :name
+      def call = expose(name:)
+    end
+  end
+
+  it "returns a plain Axn::Result on success" do
+    result = described_class.new.call(action, { name: "ada", age: 36 })
+    expect(result).to be_a(Axn::Result)
+    expect(result).to be_ok
+    expect(result.name).to eq("ada")
+  end
+
+  it "coerces wire strings without any per-field coerce: (coerce always on for tools)" do
+    result = described_class.new.call(action, { name: "ada", age: "36" })
+    expect(result).to be_ok
+  end
+
+  it "surfaces an inbound violation as a non-reported failure when user_facing_input_errors is on" do
+    expect(Axn.config).not_to receive(:on_exception)
+    invoker = described_class.new(user_facing_input_errors: true)
+    result = invoker.call(action, { name: 123, age: 36 })
+    expect(result).not_to be_ok
+    expect(described_class.input_invalid?(result)).to be(true)
+    expect(result.error).to match(/name/i)
+  end
+
+  it "input_invalid? is false for a fail! / success" do
+    ok = described_class.new.call(action, { name: "ada", age: 36 })
+    expect(described_class.input_invalid?(ok)).to be(false)
+  end
+
+  it "strips a model-supplied ambient_context from untrusted args" do
+    sensing = Class.new do
+      include Axn
+      expects :x, type: Integer
+      define_method(:call) { @seen = ambient_context }
+      attr_reader :seen
+    end
+    result = described_class.new.call(sensing, { x: 1, ambient_context: { tenant: "evil" } })
+    expect(result.__action__.seen).to eq({})
+  end
+
+  it "injects the adapter's trusted ambient_context after stripping" do
+    sensing = Class.new do
+      include Axn
+      expects :tenant, on: :ambient_context, type: String
+      exposes :tenant
+      def call = expose(tenant:)
+    end
+    result = described_class.new.call(
+      sensing,
+      { ambient_context: { tenant: "evil" } },
+      ambient_context: { tenant: "trusted" },
+    )
+    expect(result).to be_ok
+    expect(result.tenant).to eq("trusted")
+  end
+
+  it "clears CurrentCallOptions after the call" do
+    described_class.new(user_facing_input_errors: true).call(action, { name: "ada", age: 36 })
+    expect(Axn::Internal::CurrentCallOptions.current).to be_nil
+  end
+end

--- a/spec_rails/dummy_app/spec/tool_invocation_model_consistency_spec.rb
+++ b/spec_rails/dummy_app/spec/tool_invocation_model_consistency_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe "tool invocation: model-consistency mismatch surfaces user-facing" do
+  let(:action) do
+    build_axn do
+      expects :user, model: true
+      def call; end
+    end
+  end
+
+  it "composes a record/id mismatch into a non-reported user-facing failure" do
+    user = User.create!(name: "Test User")
+    other_user = User.create!(name: "Other User")
+
+    expect(Axn.config).not_to receive(:on_exception)
+    result = Axn::Tools::Invoker.new(user_facing_input_errors: true).call(
+      action, { user:, user_id: other_user.id }
+    )
+
+    expect(result).not_to be_ok
+    expect(Axn::Tools::Invoker.input_invalid?(result)).to be(true)
+    expect(result.error).to match(/conflicts with user_id/)
+  end
+end


### PR DESCRIPTION
## What & why

Adds a first-class **tool-invocation path** so adapters (`axn-mcp`, `axn-ruby_llm`) can run any Axn as a tool where a malformed, model-supplied argument comes back **structured and non-reported** — a clean "invalid arguments: …" the model can self-correct from — instead of a generic `result.error` + an `on_exception` page (a bad LLM tool call isn't a bug in our code). It also auto-coerces the trusted-JSON boundary so a tool author only needs a `type:` per input.

Linear: https://linear.app/teamshares/issue/PRO-2943/axn-tool-validation-improvements

Design/plan: `internal-docs/specs/2026-07-17-tool-input-validation-surfacing-design.md`, `internal-docs/plans/2026-07-17-pro-2943-tool-input-validation-surfacing.md`.

## Not changed (important)

Direct `.call` from ordinary app code is **byte-for-byte unchanged**: bad inbound data is still a dev issue (fires `on_exception`, generic error). Everything here is additive and **opt-in** — the framework never sniffs "am I a tool" and never globally reclassifies inbound validation. Only INBOUND violations reclassify; `fail!`, outbound violations, and genuine exceptions behave exactly as before.

## How it works — two layers

**Core: three per-call gates** on an `IsolatedExecutionState` holder (`Axn::Internal::CurrentCallOptions`), *consumed and cleared* by the executor at the top of `with_contract` so they apply only to the wrapped call and never leak into nested sub-actions:

- `coerce_input_types` — a per-call layer over the existing PRO-2884 setting; field-level explicit `coerce:` still wins; class/global still governs direct `.call`. Single-sourced (`CurrentCallOptions.coerce_input_types_for(action)`) so the executor's validation-message path and the read-path value coercion can't diverge.
- `user_facing_input_errors` — composes the whole inbound contract into one non-reported user-facing failure, reusing the existing `user_facing` settling (no new classification concept).
- `reject_undeclared_inputs` — undeclared top-level keys become normal inbound errors, exempting declared fields, subfield `on:` wire roots, `ambient_context`, and an id-based `model:` field's implicit `<field>_id`.

**Tools: `Axn::Tools::Invoker`** — holds an adapter's profile, strips a model-supplied `ambient_context` from untrusted args (the adapter injects its own trusted one), forces coercion on, runs `.call`, and returns a **plain `Axn::Result`**. `Axn::Tools::Invoker.input_invalid?(result)` (or `result.exception.is_a?(Axn::InboundValidationError)`) detects a contract violation; per-field detail is on `result.error` and the new `Axn::ValidationError#field_errors → [{field:, message:}]`. No new `Axn::Result` methods.

## Downstream follow-up (separate adapter-repo PRs)

Delete `axn-ruby_llm`'s shallow `tool_argument_validator`; swap both adapters' call sites to `Axn::Tools::Invoker`; branch on `input_invalid?` to format `{ error: "Invalid tool arguments: …" }` at full depth with zero duplication.

## Verification

Full non-Rails suite `3493 examples, 0 failures` (1 pre-existing unrelated pending); Rails dummy-app suite `306, 0 failures`; rubocop clean. Built via TDD, per-task review, and a whole-branch review.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
