### PR TITLE
Release 0.1.0-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.1.0-alpha.5
 
 ### Field contract & subfields
 
@@ -65,6 +65,7 @@
 * [FEAT] Async argument serialization uses `ActiveJob::Arguments` whenever ActiveJob is loaded (for all adapters, including Sidekiq), so GlobalID models, `Date`/`Time`/`DateTime`, `Symbol`, `Range`, `BigDecimal`, and nested symbol-keyed hashes round-trip losslessly — fixing a Sidekiq-enqueued `expects :at, type: Time` that used to arrive as a `String`. A deployment without ActiveJob accepts only JSON-native and GlobalID-able args.
 * [BREAKING] Enqueuing an async action with an unserializable argument now raises a field-aware `Axn::Async::UnserializableArgument` at enqueue time instead of silently corrupting it. The Sidekiq wire format changed to ActiveJob's `_aj_*` tagging for rich types — drain the queue across the deploy.
 * [FEAT] `Axn::Async.owns?(candidate)` answers "is this job/notice signal Axn-owned?" for error-reporter `before_notify`-style filters that suppress duplicate backend-native reports; it accepts a Class, a class-name String, or a raw Sidekiq job Hash. `Axn::Async.register_ownership_predicate` lets an adapter extend detection.
+* [FEAT] axn's per-execution state (the nesting stack, exception classification) lives in `ActiveSupport::IsolatedExecutionState`, so it isolates correctly under a fiber-based host once `isolation_level = :fiber` is set. Because axn can't set that itself (assigning it at runtime clears the store, taking ActiveRecord and `CurrentAttributes` with it), a process running a `Fiber.scheduler` under the default `:thread` isolation now gets one warning naming the fix instead of silently sharing state across concurrent fibers. Documented at `/advanced/concurrency`.
 
 ### Logging & observability
 
@@ -99,6 +100,7 @@
 * [FEAT] `inputs` returns the action's resolved declared-inbound fields as a Hash, for splatting into nested calls (`Child.call(**inputs, role: ROLE)`); `inputs` is now a reserved field name. `expose(result)` forwards a nested action result's declared exposures (the intersection with the current action's `exposes`) in one call.
 * [BUGFIX] `Axn.config.logger` no longer returns `nil` during the Rails boot window (when `Rails` is defined but `Rails.logger` isn't set yet), which had crashed any load-time log call — notably `include Axn` on a class whose ancestor defines `description`. It falls back to a transient stdout logger without memoizing, so a later call picks up `Rails.logger` once the initializer has run.
 * [BUGFIX] Re-including `Axn` in a subclass (`class Child < Parent; include Axn; end`) is now a no-op instead of silently wiping the parent's inherited `expects`/`exposes`.
+* [BUGFIX] `require "axn"` no longer raises `NameError` in a process that hasn't already loaded the stdlib `date`. The contract's type table names `Date`/`DateTime` at load time, so any consumer not picking `date` up transitively (a plain-Ruby app, not Rails) crashed on require.
 * [BUGFIX] `include Axn` no longer shadows a `description`/`input_schema`/`output_schema` class method the including class already inherits from a non-axn base (e.g. an adapter's `Tool` base where those names carry transport meaning) — axn layers its own only when the name isn't already provided.
 * [FEAT] Ship `AGENTS-consuming.md` at the gem root (packaged in the gem, readable offline via `bundle show axn`) — a dense, agent-facing cheat-sheet for code that uses Axn. README gains an "Using Axn with an AI agent" section with a copy-paste snippet.
 * [INTERNAL] The packaged gem now uses an explicit `spec.files` allowlist (`lib/` + `README`/`CHANGELOG`/`LICENSE` + the `AGENTS-consuming.md`/`AGENTS-tool-adapters.md` guides) instead of a `git ls-files` denylist, so the VitePress `docs/` site and editor/tooling files no longer ship (177 → 132 files). Contributor tooling: the pre-commit RuboCop hook moved to lefthook (`bin/setup` installs it), and `bin/new-gem` gained a `--check` conformance audit for downstream gems.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    axn (0.1.0.pre.alpha.4.3)
+    axn (0.1.0.pre.alpha.5)
       activemodel (>= 7.2)
       activesupport (>= 7.2)
 

--- a/axn.gemspec
+++ b/axn.gemspec
@@ -16,13 +16,13 @@ Gem::Specification.new do |spec|
   # NOTE: uses endless methods from 3, literal value omission from 3.1, Data.define from 3.2, Vernier profiling from 3.2.1
   spec.required_ruby_version = ">= 3.2.1"
 
-  # spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
-  # spec.metadata["rubygems_mfa_required"] = "true"
-
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "https://github.com/teamshares/axn/blob/main/CHANGELOG.md"
 
+  # Publish to RubyGems.org. Setting the host explicitly locks the push target, so `rake release`
+  # (which runs `gem push`) can't be redirected by a stray RUBYGEMS_HOST or a misconfigured remote.
+  spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["rubygems_mfa_required"] = "true"
 
   # Ship the runtime payload only — allowlist, not denylist. A gem's shippable surface is small and

--- a/bin/support/gem_generator.rb
+++ b/bin/support/gem_generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "fileutils"
+require_relative "../../lib/axn/version"
 
 # Dev-only scaffolder for downstream axn-consuming gems (PRO-2949). Shells out to `bundle gem NAME`
 # for the generic baseline, then lays axn core's canonical delta on top so a fresh gem starts
@@ -12,9 +13,12 @@ class GemGenerator
   TEMPLATES_DIR = File.expand_path("../templates", __dir__)
   CORE_ROOT = File.expand_path("../..", __dir__)
 
-  # Lower bound for the axn runtime dependency. First version to ship the DSL surface (Configurable,
-  # tool registry) downstream gems build on; the temporary Gemfile main pin tracks ahead of it.
-  AXN_LOWER_BOUND = ">= 0.1.0-alpha.4.3"
+  # Lower bound for the axn runtime dependency: core's own version, which is the newest release
+  # carrying the DSL surface (Configurable, tool registry) a generated gem builds on. Derived rather
+  # than pinned to a literal so it can't drift behind a release — a stale bound generates a gem that
+  # resolves to an axn without the constants its own scaffolding calls. The temporary Gemfile main pin
+  # tracks ahead of it.
+  AXN_LOWER_BOUND = ">= #{Axn::VERSION}".freeze
 
   # Rails testing topology:
   #   :dual — non-Rails spec/ + a spec_rails/dummy_app Rails suite (default; mirrors axn core)

--- a/lib/axn/version.rb
+++ b/lib/axn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Axn
-  VERSION = "0.1.0-alpha.4.3"
+  VERSION = "0.1.0-alpha.5"
 end


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge after #203.** That PR's CHANGELOG bullets land inside the section this PR renames, so it needs to be the last thing in before the version heading closes. The two touch different hunks, so there's no textual conflict — but merging this first would ship alpha.5 without #203's entries under it.

Closes out the `Unreleased` section as `0.1.0-alpha.5`. It's a big one: ~40 `[BREAKING]` entries spanning the field contract, subfield read-path semantics, messages/failures, async serialization, the tool registry, and the `Axn::Core`/`Axn::Extensions` namespace moves.

## Release mechanics

* `lib/axn/version.rb` → `0.1.0-alpha.5`
* `CHANGELOG.md`: `## Unreleased` → `## 0.1.0-alpha.5`
* `Gemfile.lock` + `spec_rails/dummy_app/Gemfile.lock` regenerated

## Pre-release cleanup wrapped in

**Gemspec `allowed_push_host`.** #198 pinned this for gems `bin/new-gem` generates, on the reasoning that an unpinned `gem push` can be redirected by a stray `RUBYGEMS_HOST` or a misconfigured remote. Core's own gemspec still carried `bundle gem`'s commented-out `"TODO: Set to your gem server"` placeholder — so the one gem actually being pushed today was the one without the protection. Now pinned to `https://rubygems.org`, with the dead placeholder lines removed (`rubygems_mfa_required` was already set for real a few lines down).

**`GemGenerator::AXN_LOWER_BOUND` derives from `Axn::VERSION`.** It was a literal `">= 0.1.0-alpha.4.3"`, and it had already drifted: everything a generated gem's scaffolding calls — `Axn::Configurable`, `Axn.register_tool_adapter`, `tool_roots` — is in *this* release, not 4.3. So `bin/new-gem` was emitting gemspecs that permit resolving to an axn missing the constants the generated code references. Deriving fixes the current value and closes the drift permanently, rather than adding one more literal to remember at every future bump.

**Two backfilled CHANGELOG entries** for PRs that shipped without one:
* The fiber-isolation warning (#130) — a user-visible `warn` plus a docs page, previously unmentioned anywhere in the changelog.
* The missing `require "date"` (#103) — a load-time `NameError` for any non-Rails consumer that didn't pick up the stdlib `date` transitively.

## Also checked, no action needed

* Every other commit since `v0.1.0.pre.alpha.4.3` that skipped `CHANGELOG.md` is a dependency bump, CI/docs-tooling change, or covered by a companion PR's entry.
* No stale version literals remain anywhere else (`version.rb` and the generator constant were the only two).
* No deprecation shims or tombstones to clear — the [no-tombstone convention](AGENTS.md) has been applied as we go.
* The `benchmark:check` release gate self-skips with no checked-in baseline, so it won't block `rake release`.

## Test plan

Nothing manual for review. At release time, `rake release` runs `verify` (including `verify_async`, which needs Redis) before it builds, then `benchmark:release` and `downstream:check` after — worth reading that `downstream:check` output, since `axn-mcp` / `axn-ruby_llm` / `data_shifter` / `slack_sender` all need their axn constraints widened to alpha.5 and their breaking-change migrations before they can move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)