### PR TITLE
PRO-3054: the Rails engine survives being required before Rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [BUGFIX] The Rails engine now registers even when `axn` is required before Rails. `require "axn"` loaded `axn/rails/engine` only if `Rails` was already defined, and re-requiring axn later is a no-op — so a host whose `spec_helper.rb` requires `axn/testing/spec_helpers` (the placement we document) ahead of the `rails_helper.rb` that boots the app got no engine at all. Without it `app/actions` never received its configured `app_actions_autoload_namespace`, Rails pushed the directory at the root namespace instead, and every constant under it was unresolvable — in the test environment only, so a passing boot said nothing. Introduced in 0.1.0-alpha.5, when `axn/testing/spec_helpers` began requiring `axn/testing` (and through it the full gem). The engine load is now deferred to `ActiveSupport.on_load(:before_configuration)` when Rails is absent at require time.
+
 ### Performance
 
 * [INTERNAL] The one-off ActiveModel validator class for a declared field/subfield is now compiled once per class and reused across every `.call`, instead of being recompiled (and its ActiveModel validator machinery re-instantiated) on every call. `auto_log` no longer builds its before/after payload when the configured logger's own severity level would discard it. `_model_fields` and `_declared_fields` are now cached per class instead of being rebuilt from the full contract on every reader definition / every read. Recovers roughly half of alpha-5's per-call allocation increase on the `basic` benchmark scenario — 489 → 250 objects/call (see PRO-3050).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.1.0-alpha.5.1
 
 * [BUGFIX] The Rails engine now registers even when `axn` is required before Rails. `require "axn"` loaded `axn/rails/engine` only if `Rails` was already defined, and re-requiring axn later is a no-op — so a host whose `spec_helper.rb` requires `axn/testing/spec_helpers` (the placement we document) ahead of the `rails_helper.rb` that boots the app got no engine at all. Without it `app/actions` never received its configured `app_actions_autoload_namespace`, Rails pushed the directory at the root namespace instead, and every constant under it was unresolvable — in the test environment only, so a passing boot said nothing. Introduced in 0.1.0-alpha.5, when `axn/testing/spec_helpers` began requiring `axn/testing` (and through it the full gem). The engine load is now deferred to `ActiveSupport.on_load(:before_configuration)` when Rails is absent at require time.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    axn (0.1.0.pre.alpha.5)
+    axn (0.1.0.pre.alpha.5.1)
       activemodel (>= 7.2)
       activesupport (>= 7.2)
 

--- a/lib/axn.rb
+++ b/lib/axn.rb
@@ -51,8 +51,25 @@ require "axn/util/execution_context"
 require "axn/mountable"
 require "axn/async"
 
-# Rails integration (if in Rails context)
-require "axn/rails/engine" if defined?(Rails) && Rails.const_defined?(:Engine)
+# Rails integration (if in Rails context).
+#
+# A bare `if defined?(Rails)` here would be evaluated once and never revisited, so a host that
+# requires axn BEFORE Rails would silently never get the engine -- `require "axn"` is a no-op by
+# the time Rails exists. That is the normal order in a conventional Rails test suite, where
+# `.rspec` loads a Rails-free `spec_helper.rb` (the file we tell people to put
+# `require "axn/testing/spec_helpers"` in) ahead of the `rails_helper.rb` that boots the app.
+# Without the engine, `app/actions` never gets its configured autoload namespace and every
+# constant under it is unresolvable -- in the test environment only.
+#
+# `:before_configuration` runs from `Rails::Application#initialize`, well before railties are
+# collected, so an engine defined there is still picked up. ActiveSupport is already loaded (see
+# the top of this file), and `on_load` fires immediately if the hook has already run, so the
+# deferred branch is safe whenever Rails arrives.
+if defined?(Rails) && Rails.const_defined?(:Engine)
+  require "axn/rails/engine"
+else
+  ActiveSupport.on_load(:before_configuration) { require "axn/rails/engine" }
+end
 
 module Axn
   def self.included(base)

--- a/lib/axn.rb
+++ b/lib/axn.rb
@@ -51,20 +51,10 @@ require "axn/util/execution_context"
 require "axn/mountable"
 require "axn/async"
 
-# Rails integration (if in Rails context).
-#
-# A bare `if defined?(Rails)` here would be evaluated once and never revisited, so a host that
-# requires axn BEFORE Rails would silently never get the engine -- `require "axn"` is a no-op by
-# the time Rails exists. That is the normal order in a conventional Rails test suite, where
-# `.rspec` loads a Rails-free `spec_helper.rb` (the file we tell people to put
-# `require "axn/testing/spec_helpers"` in) ahead of the `rails_helper.rb` that boots the app.
-# Without the engine, `app/actions` never gets its configured autoload namespace and every
-# constant under it is unresolvable -- in the test environment only.
-#
-# `:before_configuration` runs from `Rails::Application#initialize`, well before railties are
-# collected, so an engine defined there is still picked up. ActiveSupport is already loaded (see
-# the top of this file), and `on_load` fires immediately if the hook has already run, so the
-# deferred branch is safe whenever Rails arrives.
+# Rails integration. The `defined?` check runs once and re-requiring axn is a no-op, so a host that
+# loads axn before Rails -- the conventional RSpec layout does -- would otherwise never get the
+# engine. `:before_configuration` fires from `Rails::Application#initialize`, before railties are
+# collected, and runs immediately if Rails is already past that point.
 if defined?(Rails) && Rails.const_defined?(:Engine)
   require "axn/rails/engine"
 else

--- a/lib/axn/version.rb
+++ b/lib/axn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Axn
-  VERSION = "0.1.0-alpha.5"
+  VERSION = "0.1.0-alpha.5.1"
 end

--- a/spec_rails/dummy_app/spec/axn/autoload_paths_spec.rb
+++ b/spec_rails/dummy_app/spec/axn/autoload_paths_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe "Axn Rails autoload paths" do
       # Verify the namespace configuration is properly set
       expect(Axn.config.rails.app_actions_autoload_namespace).to eq(:Actions)
     end
+
+    # Membership in `dirs` (above) is true whether the engine namespaced the directory or Rails
+    # pushed it at the root namespace on its own, so it cannot tell the two apart. The root's
+    # namespace can, and a constant that only autoloading can supply proves it took effect.
+    it "maps the directory to the configured namespace, not the root" do
+      actions_path = Rails.root.join("app/actions").to_s
+      expect(Rails.autoloaders.main.send(:roots)[actions_path]).to eq(Actions)
+    end
+
+    it "resolves a constant under the configured namespace" do
+      expect(Actions::Clients::User.name).to eq("Actions::Clients::User")
+    end
   end
 
   describe "duplicate path prevention" do

--- a/spec_rails/dummy_app/spec/axn/engine_load_order_spec.rb
+++ b/spec_rails/dummy_app/spec/axn/engine_load_order_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "open3"
+
+# Load order is process-global and decided before this suite's own `spec_helper` runs, so these
+# have to boot a fresh Ruby. The dummy app's `spec_helper` requires `config/environment` first,
+# which is the *lucky* order — a conventional Rails app splits `spec_helper.rb` (loaded by
+# `.rspec`, before Rails) from `rails_helper.rb` (which loads the environment), so the axn
+# requires we document land before Rails exists.
+RSpec.describe "Axn Rails engine registration vs. require order" do
+  # Non-interpolating so the probe's own `#{}`s survive to the child process.
+  def probe
+    <<~'RUBY'
+      require File.expand_path("config/environment", Dir.pwd)
+      puts "engine=#{defined?(Axn::RailsIntegration::Engine) ? 'yes' : 'no'}"
+      puts "namespace=#{Rails.autoloaders.main.send(:roots)[Rails.root.join('app/actions').to_s].inspect}"
+      puts "resolve=#{begin
+        Actions::Clients::User.name
+      rescue StandardError => e
+        "#{e.class}: #{e.message}"
+      end}"
+    RUBY
+  end
+
+  def boot_with(preamble)
+    script = "#{preamble}\n#{probe}"
+
+    out, status = Open3.capture2e(
+      { "RAILS_ENV" => "test" }, RbConfig.ruby, "-e", script, chdir: Rails.root.to_s
+    )
+    raise "boot failed (#{status.exitstatus}):\n#{out}" unless status.success?
+
+    out
+  end
+
+  it "registers the engine when axn is required before Rails" do
+    output = boot_with('require "axn"')
+
+    expect(output).to include("engine=yes")
+    expect(output).to include("namespace=Actions")
+    expect(output).to include("resolve=Actions::Clients::User")
+  end
+
+  # The regression that shipped in 0.1.0.pre.alpha.5: `axn/testing/spec_helpers` pulls in the
+  # whole gem, and we document requiring it from `spec_helper.rb` — i.e. before Rails.
+  it "registers the engine when axn/testing/spec_helpers is required before Rails" do
+    output = boot_with('require "axn/testing/spec_helpers"')
+
+    expect(output).to include("engine=yes")
+    expect(output).to include("namespace=Actions")
+    expect(output).to include("resolve=Actions::Clients::User")
+  end
+
+  it "registers the engine when Rails is loaded first" do
+    output = boot_with("")
+
+    expect(output).to include("engine=yes")
+    expect(output).to include("namespace=Actions")
+  end
+end

--- a/spec_rails/dummy_app/spec/axn/rails_engine_spec.rb
+++ b/spec_rails/dummy_app/spec/axn/rails_engine_spec.rb
@@ -4,10 +4,11 @@ RSpec.describe "Axn::RailsIntegration::Engine" do
   before(:all) do
     # Ensure Rails is fully initialized
     Rails.application.initialize! unless Rails.application.initialized?
-
-    # Ensure the engine is loaded
-    require "axn/rails/engine" if defined?(Rails) && Rails.const_defined?(:Engine)
   end
+
+  # Deliberately does NOT `require "axn/rails/engine"` first: that would load the engine itself and
+  # make every example below pass whether or not booting the app registered it, which is what let
+  # the alpha.5 regression through.
 
   describe "Engine loading" do
     it "loads the Engine when Rails is available" do

--- a/spec_rails/dummy_app/spec/spec_helper.rb
+++ b/spec_rails/dummy_app/spec/spec_helper.rb
@@ -3,11 +3,15 @@
 ENV["RAILS_ENV"] ||= "test"
 ENV["RACK_ENV"] ||= "test"
 
+# Load axn testing helpers BEFORE the application, deliberately. A conventional Rails suite splits
+# a Rails-free `spec_helper.rb` (loaded by `.rspec`) from the `rails_helper.rb` that boots the app,
+# so the axn require we document lands before Rails exists. This dummy app has a single helper, so
+# ordering it the other way would make every boot-order-sensitive behavior in the suite pass for a
+# reason no host app enjoys — which is exactly how the alpha.5 engine-registration bug shipped.
+require "axn/testing/spec_helpers"
+
 # Load the dummy Rails application
 require File.expand_path("../config/environment", __dir__)
-
-# Load axn testing helpers
-require "axn/testing/spec_helpers"
 
 # Load sidekiq testing helpers
 require "sidekiq/testing"


### PR DESCRIPTION
[PRO-3054](https://linear.app/teamshares/issue/PRO-3054/axn-release-alpha-51-the-rails-engine-is-lost-when-axn-is-required)

0.1.0-alpha.5 silently drops the Rails engine in any host whose test harness requires axn before Rails — the conventional RSpec layout. Found integrating alpha-5 into os-app: every `Actions::*` constant unresolvable, `Axn::MCP.tools` returns 0, under rspec only.

## Root cause

`lib/axn.rb` gated the engine on a load-time check:

```ruby
require "axn/rails/engine" if defined?(Rails) && Rails.const_defined?(:Engine)
```

Evaluated once. If anything requires axn before Rails the engine class is never defined and never will be, because the later `require "axn"` is a no-op. Without the engine, `axn.add_app_actions_to_autoload` never runs, Rails' finisher pushes `app/actions` at the root namespace, and the configured `app_actions_autoload_namespace` is never applied.

alpha.5 is what made it fire: PRO-2997 (#216) added `lib/axn/testing.rb`, which does `require "axn"`, and put `require "axn/testing"` at the top of `lib/axn/testing/spec_helpers.rb`. We document requiring that helper from `spec_helper.rb`, and `.rspec` loads `spec_helper.rb` before the `rails_helper.rb` that boots the app. alpha.4.3's `spec_helpers.rb` had no requires.

A/B in the os-app worktree, one line apart:

| | engine defined | `app/actions` root ns | `Actions::Zendesk::User::Sync` |
| --- | --- | --- | --- |
| `require config/environment` | yes | `Actions` | resolves (`Axn::MCP.tools` → 7) |
| `require "axn/testing/spec_helpers"` first | no | `Object` | `NameError` |

Not a Zeitwerk ordering bug: Rails >= 7.1's `:setup_main_autoloader` keeps `already_configured_dirs = Set.new(autoloader.dirs)` and skips re-pushing, precisely so an engine's namespaced `push_dir` wins.

## Fix

```ruby
if defined?(Rails) && Rails.const_defined?(:Engine)
  require "axn/rails/engine"
else
  ActiveSupport.on_load(:before_configuration) { require "axn/rails/engine" }
end
```

`active_support` is already required at the top of the file; `:before_configuration` runs from `Rails::Application#initialize`, before railties are collected; `on_load` fires immediately if the hook already ran. `lib/axn.rb:55` was the only load-time framework gate in `lib/`.

## Why the suite missed it, and what changed

1. **The dummy app booted in the lucky order.** Its `spec_helper.rb` required `config/environment` before `axn/testing/spec_helpers` — the one order no host app uses. Swapped, so all 354 spec_rails examples now boot the way a real suite does.
2. **`rails_engine_spec.rb` re-required the engine in `before(:all)`**, so it would have loaded the engine itself and passed regardless. Removed.
3. **`autoload_paths_spec.rb` asserted membership, not effect.** `Rails.autoloaders.main.dirs` includes `app/actions` in *both* states. It now asserts the roots-to-namespace mapping and resolves a constant.

New `spec_rails/dummy_app/spec/axn/engine_load_order_spec.rb` boots a fresh Ruby in three require orders (axn first, `axn/testing/spec_helpers` first, Rails first), since load order is settled before the suite's own helper runs.

## Verification

- New spec failed 2/3 before the fix (`engine=no`, `namespace=Object`, `NameError: uninitialized constant Actions`), passes 3/3 after.
- Guard proven by reverting `lib/axn.rb` on the reordered helper: the spec_rails suite dies at load with `uninitialized constant Actions`, 0 examples run.
- os-app's `spec/requests/mcp_controller_spec.rb` goes 0/14 → 14/14 with the fixed `lib/axn.rb` dropped over the installed alpha.5 gem.
- 5,095 + 354 examples green, RuboCop clean.

## Test plan

- [ ] After merge and the 5.1 tag, re-point os-app `kali/pro-1610-axn-release-alpha-5` at the release and run its suite (needs the released gem, not a local patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)