### PR TITLE
PRO-3057: split AGENTS.md's rules from its case studies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,9 +126,11 @@ Reuse the hierarchy in `lib/axn/exceptions.rb`; don't invent ad-hoc classes. Eve
 explains the problem **and** the fix (see `UnknownExposure`). New messages meet that bar.
 
 Before touching anything on the failure-settlement or error-reporting path — `_settle_exception!`,
-`best_effort`, a message resolver, `Internal::Rendering`/`Internal::Text`, any serialization or
-reflection error path, or a `rescue` on the result path — read
-`internal-docs/agent-notes/error-paths.md` first. The rules it backs:
+any `Axn::Extensions` method (not just `best_effort`), a message resolver,
+`Internal::Rendering`/`Internal::Text`/`Internal::NativeMethods`, `Internal::ShapeGraph`'s
+option-container copy, the contract's declaration walk, any serialization or reflection error
+path, or a `rescue` on the result path — read `internal-docs/agent-notes/error-paths.md` first.
+The rules it backs:
 
 - `Axn::Extensions.best_effort` guards a side channel and swallows `StandardError` plus
   `SWALLOWABLE_BEYOND_STANDARD_ERROR`. Pass `standard_errors_only: true` only when no side effect is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 Guidance for agents working in **Axn**. Read before writing code.
 
+This file governs axn-core itself. Two siblings cover adjacent work: read `AGENTS-consuming.md`
+before building or maintaining a gem that depends on axn; read `AGENTS-tool-adapters.md` before
+touching a tool adapter (`Axn::Tools`, `tool_paths`, `Invoker`/`owns_failure_exception`).
+
 ## The bar
 
 Axn is the base layer for service objects — the `expects` / `exposes` / `call` contract that
@@ -61,7 +65,7 @@ axn-core reserves the top-level public constants (`Result`, `Failure`, `Factory`
 Which namespace a new constant belongs in, so the next addition follows a rule instead of copying a precedent:
 
 - `Internal::X` — internal **and generically useful**: a value-level mechanism any layer can use, with no presence in the action's surface. `CycleGuard`, `ShapeGraph`, `NativeMethods`, `Timing`, `Callable`, `ClassName`, `Text`, `Rendering`.
-- `Internal::Reflection::X` — the layer that derives a JSON view of a contract, and only that: `Schema`, `Values`, `PropertyNames`. Nothing outside axn names it; what a gem consumes are the projections — `input_schema`/`output_schema` on the action class, and `Extensions::Serialization.render` for a result. Building and validating a schema, and rendering a result, mostly run off the execution path, but that's not a blanket guarantee of membership: `Schema` and `PropertyNames` each keep a narrow foothold ON it (a memoized model-field default check; a small set of runtime callers naming a field only when reporting a failure), while `Values` has none — see `Internal::Reflection`'s own header for exactly which callers and when. Anything that runs during validation or at declaration belongs at `Internal::X` (`Coercion`, `SubfieldTree`, `ResolvedSubfields`) or in the layer it serves (`Core::Contract::SubfieldContradictions`).
+- `Internal::Reflection::X` — the layer that derives a JSON view of a contract, and only that: `Schema`, `Values`, `PropertyNames`. Nothing outside axn names it; what a gem consumes are the projections — `input_schema`/`output_schema` on the action class, and `Extensions::Serialization.render` for a result. Anything that runs during validation or at declaration belongs at `Internal::X` (`Coercion`, `SubfieldTree`, `ResolvedSubfields`) or in the layer it serves (`Core::Contract::SubfieldContradictions`). Deciding whether a specific runtime foothold still counts as membership? Read `internal-docs/agent-notes/namespaces.md` first.
 - `Core::X` — internal **and contextual to one topic**: a layer extended onto the action class, named for what the *author* writes. `Contract`, `Hooks`, `Tagging`, `Logging`, `AmbientContext`, `ToolDeclaration`.
 - `Core::Contract::X` — machinery one layer owns and that is meaningless outside it. `FieldConfig` (the contract's config object — the same-named `Internal::FieldConfig` is the field-name convention helper), `ShapeConfig`, `ShapeDeclaration`, `Redaction`.
 - `Extensions::X` — axn **or downstream gems**. The only namespace a gem should add constants to, and adding one is adding to the public API.
@@ -69,7 +73,14 @@ Which namespace a new constant belongs in, so the next addition follows a rule i
 
 A namespace is not a substitute for `private`. `Axn::Configurable` is `extend`ed onto each consuming gem's own module, so an underscore-named method there is a public method of `Axn::MCP` / `Axn::OpenAPI` / `DataShifter` — "internal by namespace" guarantees nothing. Underscore-name AND `private` unless a cross-file caller with an explicit receiver needs it, and record why when one does.
 
-`Axn::Error` is the public-error boundary, and it is a **module** rather than a base class: `rescue` matches a module by `is_a?`, so tagging a class costs it no ancestry — which is what lets four core errors stay `ArgumentError`s and lets an adapter gem keep a base its own ecosystem requires (`Faraday::Error`, `Timeout::Error`) while still being catchable as an axn error. Including it is the boundary DECLARATION, not a blanket sweep: a class that includes it is public, documented, rescuable and breaking to remove. A sibling gem roots its own hierarchy there — `class Axn::Webhooks::Error < StandardError; include Axn::Error; end` — and `spec/axn/error_policy_spec.rb` pins the exact set of untagged classes, so neither an untagged public error nor a tagged internal one can land. `Axn::Failure` is the one deliberate public exclusion: it is a control-flow signal from `call!`, not a fault, so tagging it would make `rescue Axn::Error` catch the intended outcome while still missing an unintended `NoMethodError` from the action body. No public exception class inherits out of `Axn::Internal`; where six once did, the internal base was an ancestor and nothing else, and `rescue Axn::Error` is how "any registry lookup miss" is expressed now.
+`Axn::Error` is the public-error boundary and a **module**, not a base class: `rescue` matches by
+`is_a?`, so tagging a class costs it no ancestry. Including it is the boundary DECLARATION, not a
+blanket sweep — a class that includes it is public, documented, rescuable and breaking to remove;
+`spec/axn/error_policy_spec.rb` pins the exact set of untagged classes, so neither an untagged
+public error nor a tagged internal one can land. `Axn::Failure` is the one deliberate public
+exclusion: it's a control-flow signal from `call!`, not a fault. No public exception class inherits
+out of `Axn::Internal`. Adding a new error class, or deciding whether it should include
+`Axn::Error`? Read `internal-docs/agent-notes/namespaces.md` first.
 
 ## DSL & API patterns
 
@@ -88,57 +99,64 @@ A namespace is not a substitute for `private`. `Axn::Configurable` is `extend`ed
   *meaning* (`<field>_id` is always the primary key) must be honored on every path, blank/edge
   inputs included.
 - **A guard derives from what its consumer emits; it never predicts it.** When a check must agree
-  with a projection — the property-name rules against `Internal::Reflection::Schema`'s emitted properties, say
-  — read the consumer's own output or call the consumer's own decision (`Schema.shape_property_plan`,
-  `Schema.build_input_for`), rather than re-deriving the answer beside it. A predictor is wrong in two
-  directions at once and both are worse than a late diagnosis: it misses what the consumer emits by a
-  path the predictor doesn't know, and it *rejects legal declarations* the consumer would never emit
-  at all. SEVEN defects on one PR shared that root, and each seam-by-seam fix generated the next one
-  until every charge and claim was routed through the emitter's own decision. The last two were in a
-  size BUDGET rather than a name check, which is the form to watch for: a per-declaration charge
-  predicts "this will emit a property", so it rejected a contract whose schema names nothing — a config
-  rooted at `on: :ambient_context`, a subfield under a parent that cannot hold object properties, a
-  `model:` route's own type on input. A budget spends on what the emitter emits (`SubfieldTree`'s index
-  and `path_blocked?`, `Schema.shape_property_plan`) or it is a predictor with a number attached. And
-  when a charge cannot be exact, know which way it errs and say so: UNDER-counting only loosens a
-  bound, while OVER-counting rejects a legal declaration. This is also why a check may legitimately
-  fire later than declaration: if only the emitted schema reveals a collision, the honest promise is
-  "before anything can consume it" (at app setup for tools, via `Axn::Tools.validate_contracts!`), not
-  "at declaration".
+  with a projection, read the consumer's own output or call its own decision
+  (`Schema.shape_property_plan`, `Schema.build_input_for`) rather than re-deriving the answer beside
+  it — a predictor both misses what the consumer emits by an unknown path AND rejects legal
+  declarations the consumer would never emit. When a charge can't be exact, know which way it errs:
+  UNDER-counting only loosens a bound, OVER-counting rejects a legal declaration. A check may
+  legitimately fire later than declaration — "before anything can consume it," not "at
+  declaration" — if only the emitted schema reveals the problem. Before writing a guard or size
+  budget against a projection, read `internal-docs/agent-notes/guards-and-projections.md` first.
 - **Canonicalizing a value obliges you to re-audit every guard that read the raw form.** Symbolizing
   keys, defaulting an absent list to `[]`, normalizing a name — each silently disarms any downstream
-  check that distinguished what you just erased. Three regressions on one PR: `[]`-for-absent hid
-  `ShapeValidator`'s "must supply :members"; String-keyed option bags hid `_reject_model_transform!`
-  and made `FieldOptionality#optional?` answer `false` for a declared `allow_blank`, publishing a
-  wrong `required` list that adapters build tool definitions from. Enumerate the consumers of both
-  forms in the same commit, and say which still fire.
+  check that distinguished what you just erased. Enumerate the consumers of both forms in the same
+  commit, and say which still fire. (Case studies: `internal-docs/agent-notes/guards-and-projections.md`.)
 - **An optimization that returns the caller's object unchanged is an aliasing bug.** A fast path
   skipping work because "nothing needs changing" answers a different question than "nothing needs
   copying" — a declared contract must be axn's own, so mutating what the caller still holds cannot
-  change it retroactively. One exception, and it is the same question answered rather than dodged: an
-  option container that is already FROZEN is stored as the caller's object
-  (`Internal::ShapeGraph.detached_option_array`), because "nothing can change it afterwards" is precisely
-  the property the copy was buying — to the same one-level depth, since a frozen container's elements are still the
-  caller's objects, exactly as a copy's are. And a copy detaches only what it actually copies: `Kernel#dup`
-  copies an Array's ELEMENTS while sharing the instance variables and dropping the singleton class, so a
-  container whose own code answers from either is not detached by being copied, it is silently changed.
+  change it retroactively. One exception: an already-FROZEN container is stored as the caller's
+  object (`Internal::ShapeGraph.detached_option_array`), since "nothing can change it afterwards" is
+  the same property a copy would buy. Before writing a fast path over a caller-supplied container,
+  read `internal-docs/agent-notes/guards-and-projections.md` first — a copy detaches only what it
+  actually copies, and getting that wrong is the recurring bug there.
 
 ## Errors
 
 Reuse the hierarchy in `lib/axn/exceptions.rb`; don't invent ad-hoc classes. Every `message`
 explains the problem **and** the fix (see `UnknownExposure`). New messages meet that bar.
 
-`Axn::Extensions.best_effort` guards a **side channel** — a log line, a span update, a metrics block, an error report — and swallows `StandardError` plus `SWALLOWABLE_BEYOND_STANDARD_ERROR`, so nothing in it can take down the call it observes. Pass `standard_errors_only: true` only when letting a non-`StandardError` escape is genuinely better than swallowing it — which requires BOTH that no side effect is already committed at that point AND that an executor boundary will settle the escape into a reported result rather than re-raising. Resolving a `model:` record qualifies: it runs inside its own action's validation, so a runaway finder surfaces as a reported exception result naming the real stack instead of a misleading "can't be blank". A post-fan-out `on_enqueue_all` callback does not: jobs are already enqueued and the orchestrator is itself an async job whose adapter re-raises an exception outcome, so an escape gets the batch enqueued twice. Two further rules keep this from going wrong: apply the flag at exactly ONE layer per callable, the layer that invokes it (`Handlers::Invoker` owns the policy for everything it dispatches, so callbacks/matchers/messages must not re-guard on top of it); and never let a site's behavior depend on which error class a callable raised — if `StandardError` is swallowed and skipped there, a `SystemStackError` must be too. `SWALLOWABLE_BEYOND_STANDARD_ERROR` is also what `Core::Executor` may settle onto a result (via `Extensions.swallowable?`), so it is the single answer to "what will axn ever swallow". Keep it an allowlist and widen it only for a class that is unambiguously a fault in the code being run: the non-`StandardError` set is open-ended (any gem can define a direct `Exception` subclass), and members like `Timeout::ExitException` and `ActiveSupport::ErrorReporter::UnexpectedError` exist precisely so nothing swallows them. Absorbing one silently breaks whatever it signals, which is far harder to trace than an unrecognized bug escaping `.call`.
+Before touching anything on the failure-settlement or error-reporting path — `_settle_exception!`,
+`best_effort`, a message resolver, `Internal::Rendering`/`Internal::Text`, any serialization or
+reflection error path, or a `rescue` on the result path — read
+`internal-docs/agent-notes/error-paths.md` first. The rules it backs:
 
-Separate the caller code a walk **requires** from caller code invoked while **reporting** a failure. The first is unavoidable — rendering a value calls its `to_s`/`as_json`, walking a container calls its `each` — and a value that lies there changes what we decide, which is the caller's own problem. The second is different in kind: an `inspect`, a `class`, an `is_a?`, or a `-@` called to build the message can raise and *replace* the failure with the caller's exception, and if that exception is outside `StandardError` it escapes the adapter's `rescue` — reinstating exactly what the error existed to prevent. So in a serialization or reflection error path, derive what the message needs without dispatching: describe a value by `Object.instance_method(:class).bind_call(it)` rather than `it.class` or `it.inspect`, and write type tests as `case`/`when` (`Module#===` is a C-level check) rather than `is_a?`, which a value can override to route around a guard. A fast path that adds a dispatch the work does not require — skipping an allocation by asking a key what class it is — is not worth it. Eight layers hold this property: `Internal::Reflection::Values`, `Internal::Reflection::PropertyNames`, `Internal::ShapeGraph`, `Internal::NativeMethods`, `Internal::Text`, `Internal::Rendering`, `Axn::Extensions`, and the contract's declaration walk — including the option-container copy `Internal::ShapeGraph` owns, where `Kernel#dup` and `Hash#each` are BOUND rather than dispatched, so simplifying `Hash#each` back to a plain `.each` reopens an aliased contract (a bag is copied entry-wise whatever its class); the bound `dup` is belt-and-braces, since an Array owning `dup` is refused before the copy is attempted.
-
-And a rule one step further out, because guarding a dispatch is not always possible: **do not build a guard that depends on foreign behaviour being honest.** Verifying that a caller's object BEHAVES is unbounded — the body is arbitrary code, so every round of verification is defeated by the next case. Two on one PR: an option container was copied and the copy compared, first by elements (defeated by a duplication hook that dropped a derived membership index) and then by asking the copy `include?` about each element (defeated by a hook that dropped only the index of accepted NON-elements, since membership is not enumerable from outside); and a contract failure was renamed and re-raised on the argument that having been raised once made a redispatch safe (defeated by an `#exception` answering itself the first time and raising the second, because renaming CLONES and `raise` then asks the clone). Ask OWNERSHIP instead — `Internal::NativeMethods`, reading owners out of the method table rather than running the object — and take a simple honest fallback when the object is not native: refuse the container (`freeze` it is the documented escape), report axn's own error with the original as `cause`. A bounded rule that over-rejects slightly beats an unbounded verification. But a bounded rule can still be scoped WRONG, and the container half was, twice over: owning the duplication hooks is not what makes a copy faithful (the copy's answers must be determined by the state `dup` copies faithfully — the elements — which holds only where the answers are Ruby's own), and the lookup has to go where the answer will be read. So `own_array_methods` asks for everything the container answers with, through its SINGLETON CLASS's ancestry (one walk over singleton methods, extended modules and the class's own), because a consumer asks the ORIGINAL and a copy carries no singleton. The exception half keeps a named set and an object lookup for a different question — what raising will DISPATCH: `clone` copies the singleton class and `raise` asks the object it is handed, while `dup` looks its hooks up on the copy's class. Separately, every layer that writes a declared NAME into prose routes it through `PropertyNames.inspect_field_name`/`renderable_label` — the contract's declaration errors, `shape_validator`, `subfield_contradictions`, `call_logger` — so no message renders a name by running the name's own code. And not running the offender's code is only HALF of what prose needs, because the bytes it hands back are foreign too: a message axn builds is UTF-8, so joining a String that has no UTF-8-compatible rendering to one raises `Encoding::CompatibilityError` from the reporting itself — which is why those layers RENDER what they write (`renderable_label`: an ASCII string is byte-identical, another encoding reads as its text, unrenderable bytes come back escaped), and why a CLASS written into a message goes through the one seam that composes both halves (`PropertyNames.renderable_class_name`/`renderable_module_name` over `Internal::ClassName`) — a constant may hold non-UTF-8 bytes, so naming a class destroyed the report from inside the `a name of class …` fallback the name rules escape TO, and from `Axn::Tools.validate_contracts!` naming a tool. A guarded dispatch and a rendered result are two obligations, and every site that met one of them by hand met only that one. The byte primitive lives at the BOTTOM of the gem (`Internal::Text`, zero requires) for exactly this reason: `Internal::Reflection::Values`' colliding-key report and both `UnserializableValue#message` and `Axn::Async::UnserializableArgument#message` sit in the files the renderer is itself built on, so a primitive any higher is out of their reach, and one at the bottom is what lets them compose both halves like every other layer — as `Axn::Extensions.best_effort` does, from a file that requires none of the reflection stack. That property is what the layers own, and it is not a property of the guard AROUND one step: `PropertyNames.attributions` rescues the provenance WALK, so everything the failure path then does with the walk's result — the path lookup, the wording choice, each name written into the message — has to dispatch nothing itself, which is why `same_declared_name?` (identity, or a bound `String#==`) replaced `Array#==` in the lookup and `==` in the contract's wording choice, and why the collision walk canonicalizes each emitted name ONCE and reuses it wherever the path is written. Nor is a guard that only counts exempt: the size budget keys a wire key by `wire_key_segment` (a plain copy) and a member name by `property_segment` (a bound intern), never by handing the name to a Hash and letting its own `hash`/`eql?` answer axn's question. Six dispatches were examined and deliberately left. Four are caller DATA or prose: the runtime redaction walk type-tests caller data (`is_a?`, `dup`) on every logged call, `Array(klass)` dispatches `to_a` on a caller value, `shape_validator` reports `got #{source.class}`, and `subfield_contradictions` lists declared type branches with `#inspect`. Two are the projection's own work, both in `Internal::Reflection::Schema`, which is deliberately NOT one of the layers above: `properties[config.field] =` IS the merge rule (one Hash key means "two routes, one property, legal"), and `required << config.field.to_s` renders the name JSON will carry — so a declared name whose `eql?` or `to_s` raises has no property map and the emitter says so, exactly as a value whose `to_s` raises cannot be rendered. `Internal::Reflection::Values.canonical_wire_key` reads a String's or Symbol's rendering WITHOUT dispatching for the same reason the rules do — it is their input, so a dispatch there is a dispatch inside a verdict — and dispatches `to_s` only for a name that is neither, where rendering it is the only way to know what property it names. Where such a dispatch is unavoidable, ask ONCE: canonicalizing a name to reach the unrenderable check and canonicalizing again inside it let a second, different answer overturn a verdict already reached, and the schema then advertised a property the contract does not have — the same bytes being REJECTED under a name that renders them honestly, since `JSON.generate` asks a key's own `to_s` as well and emits whatever the name last claimed. A guard defeated by exactly the object it exists to catch is the shape to watch for. But reading a String's bytes is only HALF of what a verdict needs, and choosing the other candidate would only have swapped which half was wrong: `JSON.generate` renders a Hash key through its `to_s`, so a name whose rendering disagrees with its bytes is judged as one property and emitted as another — a subclass holding `"other"` and rendering `"dup"` passed the collision rules beside a `:dup` field and then emitted `"dup"` twice, and a plain String carrying a singleton `to_s` needed no second declaration at all, since the emitter's `required` list named a property its `properties` map does not define. So a declared name that renders through code of its own is REFUSED (`NativeMethods.native_name_rendering?` — a Symbol can carry no override, a String must not own `to_s`), which is what makes judging the bytes sound rather than arbitrary, and every artifact reads the one name one way (`Schema.required_key`). Where three readers pick between two candidate renderings, no choice of candidate is a fix; only removing the second candidate is. Caller data is a different category from an error path: there the dispatch IS the work (rendering a value requires its `to_s`), and a value that lies degrades a log line or masks more than necessary. But being inside a guard is not what makes that safe, and `best_effort` is the counterexample: it built its warning from the exception it had just caught — that exception's class name, its message, its backtrace — so an exception whose `#message` raises, or an ordinary one whose STORED message holds bytes with no UTF-8 rendering, escaped through the very code meant to contain it, was absorbed one layer out, and replaced the settled outcome, leaving `result.exception` naming the reporting failure instead of the caller's `InboundValidationError`. A guard has to hold the property in the code that REPORTS, not only in the code it wraps, which is why every fact the warning names is read through `Internal::Rendering` and the emit itself is backstopped.
-
-Render a composed message at the **join**, never operand by operand. Half-rendering is strictly worse than rendering nothing: an `Encoding::CompatibilityError` needs INCOMPATIBLE operands, and two ISO-8859-1 Strings concatenate fine — so transcoding one of them and leaving its neighbour raw converts a composition that worked into a raise. That is not hypothetical, it is how the rendering funnel was first built and it broke three separate paths that way: a Latin-1 `fail!` reason beside a Latin-1 `join:` separator (`result.error` raised), a Latin-1 field name beside a Latin-1 `default:` failure (`Encoding::CompatibilityError` in place of `DefaultAssignmentError` — a reporting failure replacing the real error, the exact defect the funnel exists to prevent), and a Latin-1 declared name beside a `Date` whose registered `:inspect` format returned Latin-1. The reason it kept recurring is that per-operand rendering requires ENUMERATING the operands, and each enumeration missed a branch the next one found — the third case was a regression introduced by the fix for the second. So normalization belongs at the one point every operand flows through, the way `MessageResolver#body_for` owns it for handler returns: per-branch rendering is sound only where the dispatch is an exhaustive type test whose every branch ends in the funnel, which is what a funnel IS. A fix whose correctness depends on six call sites each remembering to render is not a fix; it is six chances to be wrong, and the audit that found that one had already been wrong twice.
-
-A finding reachable only by an object built to defeat the guard does not earn an exhaustive fix — that pursuit is unbounded, since a worse object can always be invented — but it does earn an AUDIT of the area, because such a report is evidence the area was written without the hazard in mind. Triage it by asking whether the fix completes an invariant or adds another special case. Three reasons that have held up: it removes a duplicate policy for one question (a method owner was resolved in three places with three different absence policies, and closing that also closed a second caller the report never mentioned); it is the last unguarded instance in a module whose whole purpose is the guard (once `first_frame` read the backtrace container through a bound `Array#first`, every remaining dispatch in `Internal::Rendering` was deliberate, guarded and documented, so the file's stated promise became true rather than nearly true); or it fails safe at the same cost as the dispatch it replaces. What does NOT justify one is that the scenario is imaginable. And the audit is the deliverable even when the patch is declined — say what you examined and what you left, because "I found nothing else of this shape" is the useful answer and is only worth anything if you looked.
-
-Any code that recurses through caller-supplied Hash/Array values must cycle-guard with `Axn::Internal::CycleGuard.guard` (a self-referential value is a `SystemStackError`, which is outside `StandardError` and so escapes the whole result path). A walk that descends a caller value **in lockstep with a shape graph** guards on the PAIR instead (`CycleGuard.guard_pair`), because neither half alone is the walk's position: the same value legitimately reappears under a different shape node with members still to validate, so keying on the value stops a walk that is not looping and drops real verdicts, while keying on the shape stops descending a value that still has members. Pairs only repeat while the graph does, so such a walk needs `ShapeGraph::MAX_NESTING` as well — a graph that mints a fresh nested shape per read is endless rather than cyclic and repeats nothing at all. For third-party code that recurses and can't be guarded from inside — `ActiveSupport::ParameterFilter` — rescue `SystemStackError` and retry on `CycleGuard.decycle(data)`, so acyclic data pays for neither the extra walk nor the copy.
+- `Axn::Extensions.best_effort` guards a side channel and swallows `StandardError` plus
+  `SWALLOWABLE_BEYOND_STANDARD_ERROR`. Pass `standard_errors_only: true` only when no side effect is
+  committed yet AND an executor boundary will settle the escape into a reported result. Apply the
+  flag at exactly one layer per callable — the layer that invokes it — and never let behavior depend
+  on which error class was raised. Widen `SWALLOWABLE_BEYOND_STANDARD_ERROR` only for a class that's
+  unambiguously a fault in the code being run.
+- In an error-reporting or serialization path, derive message content without dispatching to the
+  caller's own methods — bound methods (`Object.instance_method(:class).bind_call`) instead of
+  `.class`/`.inspect`, `case`/`when` instead of `is_a?`. Dispatch on caller *data* is a different
+  question and is fine when the dispatch **is** the work (normal rendering, validation) — this rule
+  is only about the reporting path itself.
+- Don't build a guard that depends on foreign behaviour being honest — verifying that an object
+  BEHAVES is unbounded. Ask ownership (`Internal::NativeMethods`) instead, and refuse (`freeze` is
+  the documented escape) when the object isn't native.
+- Every declared name written into prose routes through `PropertyNames`'s renderers — never render a
+  name by running the name's own code — and a name is canonicalized exactly once per verdict, never
+  re-canonicalized inside a nested check.
+- Render a composed message at the join, never operand by operand: half-rendering breaks encoding
+  compatibility that would otherwise hold.
+- A finding reachable only by an adversarial/hostile object earns an audit of the area, not an
+  exhaustive fix — justified by completing an invariant, closing the last unguarded instance in a
+  guard-purpose module, or failing safe at equal cost. Report what you examined even when declining
+  the patch.
+- Cycle-guard any recursion through caller-supplied Hash/Array with `Axn::Internal::CycleGuard.guard`.
+  A walk descending in lockstep with a shape graph guards on the pair (`guard_pair`) plus
+  `ShapeGraph::MAX_NESTING`. For third-party recursion that can't be guarded from inside, rescue
+  `SystemStackError` and retry on `CycleGuard.decycle(data)`.
 
 ## Testing
 
@@ -154,37 +172,10 @@ Any code that recurses through caller-supplied Hash/Array values must cycle-guar
   pinning what a guard must keep ACCEPTING. Over-rejection is the recurring failure mode when a guard is
   tightened, so audit controls by **inverse** mutation instead: introduce an over-eager guard and confirm a
   control fails.
-- **Changing a guard? A/B the spec against the prior commit.** A spec suite can only tell you the current
-  tree is self-consistent; running today's assertions against yesterday's `lib/` tells you which behaviours
-  a change actually moved.
-
-  ```sh
-  git worktree add -f --detach /tmp/axn-ab <OLDER_SHA>
-  cp spec/axn/core/validations/<the_spec>.rb /tmp/axn-ab/spec/axn/core/validations/
-  (cd /tmp/axn-ab && bundle exec rspec spec/axn/core/validations/<the_spec>.rb)
-  git worktree remove --force /tmp/axn-ab
-  ```
-
-  Read the differences one by one: an example that fails THERE and passes here is a behaviour this change
-  moved, and an unexpected one is a regression. **An example that fails in BOTH is a broken fixture, not a
-  finding** — that distinction is the one that repeatedly mattered, because a stale fixture reads exactly
-  like a regression until you check the other side. A mixed result is normal and is the useful case: only the
-  examples whose behaviour the change actually moved flip.
-
-  `bundle exec` needs no `bundle install` in the worktree while `Gemfile.lock` is unchanged between the two
-  commits — the gems are already resolved. If the older commit's lockfile DOES differ, install there first;
-  otherwise every example fails for the same uninteresting reason, which is the commonest cause of a
-  fails-in-both reading.
-
-  **Run each side from inside its own checkout**, as above — never require the other tree's files from this
-  one. axn's internal requires are non-relative (`require "axn/…"`), so they resolve against `$LOAD_PATH`,
-  which under this checkout's bundle points back here: only the outermost `require_relative` lands in the
-  other tree and everything beneath it is silently THIS tree's code. Between nearby refs that succeeds and
-  reports today's behaviour for both sides — a zero delta that looks like "the change had no effect" —
-  while between distant ones it surfaces as a confusing `LoadError` for a file the other tree never had.
-  The benchmark harness hard-fails on the mismatch (`benchmark/support/axn_scenarios.rb` compares
-  `Object.const_source_location("Axn::VERSION")` against its own root), so a profiling A/B cannot make this
-  mistake quietly; a hand-rolled script that loads `lib/axn` some other way still can.
+- **Changing a guard? A/B the spec against the prior commit.** An example that fails in BOTH trees
+  is a broken fixture, not a finding — only the examples whose behaviour the change actually moved
+  flip. Read `internal-docs/agent-notes/ab-testing-guards.md` for the exact procedure and its
+  pitfalls (stale lockfiles, `$LOAD_PATH` cross-tree contamination) before running one.
 
 ## Changes & compatibility
 

--- a/internal-docs/agent-notes/ab-testing-guards.md
+++ b/internal-docs/agent-notes/ab-testing-guards.md
@@ -1,0 +1,43 @@
+# A/B-testing a guard change: procedure and pitfalls
+
+This file holds mechanism and case studies only. The rule each section backs is stated in
+`AGENTS.md`; if you find yourself wanting to add a new rule here instead of there, put it in
+`AGENTS.md` and link back.
+
+## Why this exists
+
+A spec suite can only tell you the current tree is self-consistent; running today's assertions
+against yesterday's `lib/` tells you which behaviours a change actually moved.
+
+## Procedure
+
+```sh
+git worktree add -f --detach /tmp/axn-ab <OLDER_SHA>
+cp spec/axn/core/validations/<the_spec>.rb /tmp/axn-ab/spec/axn/core/validations/
+(cd /tmp/axn-ab && bundle exec rspec spec/axn/core/validations/<the_spec>.rb)
+git worktree remove --force /tmp/axn-ab
+```
+
+Read the differences one by one: an example that fails THERE and passes here is a behaviour this
+change moved, and an unexpected one is a regression. **An example that fails in BOTH is a broken
+fixture, not a finding** — that distinction is the one that repeatedly mattered, because a stale
+fixture reads exactly like a regression until you check the other side. A mixed result is normal
+and is the useful case: only the examples whose behaviour the change actually moved flip.
+
+## Pitfalls
+
+`bundle exec` needs no `bundle install` in the worktree while `Gemfile.lock` is unchanged between
+the two commits — the gems are already resolved. If the older commit's lockfile DOES differ,
+install there first; otherwise every example fails for the same uninteresting reason, which is the
+commonest cause of a fails-in-both reading.
+
+**Run each side from inside its own checkout**, as above — never require the other tree's files
+from this one. axn's internal requires are non-relative (`require "axn/…"`), so they resolve
+against `$LOAD_PATH`, which under this checkout's bundle points back here: only the outermost
+`require_relative` lands in the other tree and everything beneath it is silently THIS tree's code.
+Between nearby refs that succeeds and reports today's behaviour for both sides — a zero delta that
+looks like "the change had no effect" — while between distant ones it surfaces as a confusing
+`LoadError` for a file the other tree never had. The benchmark harness hard-fails on the mismatch
+(`benchmark/support/axn_scenarios.rb` compares `Object.const_source_location("Axn::VERSION")`
+against its own root), so a profiling A/B cannot make this mistake quietly; a hand-rolled script
+that loads `lib/axn` some other way still can.

--- a/internal-docs/agent-notes/error-paths.md
+++ b/internal-docs/agent-notes/error-paths.md
@@ -1,0 +1,227 @@
+# Error paths: case studies and mechanism
+
+This file holds mechanism and case studies only. The rule each section backs is stated in
+`AGENTS.md`; if you find yourself wanting to add a new rule here instead of there, put it in
+`AGENTS.md` and link back.
+
+## `best_effort`'s escape policy
+
+`Axn::Extensions.best_effort` guards a side channel — a log line, a span update, a metrics block,
+an error report — and swallows `StandardError` plus `SWALLOWABLE_BEYOND_STANDARD_ERROR`.
+`standard_errors_only: true` lets a non-`StandardError` escape instead of being swallowed, but only
+when doing so is genuinely better — both that no side effect is already committed at that point,
+and that an executor boundary will settle the escape into a reported result rather than re-raising.
+
+Two contrasting cases:
+
+- Resolving a `model:` record qualifies: it runs inside its own action's validation, so a runaway
+  finder surfaces as a reported exception result naming the real stack instead of a misleading
+  "can't be blank".
+- A post-fan-out `on_enqueue_all` callback does not: jobs are already enqueued and the orchestrator
+  is itself an async job whose adapter re-raises an exception outcome, so an escape gets the batch
+  enqueued twice.
+
+The flag is applied at exactly one layer per callable — the layer that invokes it
+(`Handlers::Invoker` owns the policy for everything it dispatches, so callbacks/matchers/messages
+must not re-guard on top of it). Behavior never depends on which error class was raised: if
+`StandardError` is swallowed and skipped at some site, a `SystemStackError` must be too.
+
+`SWALLOWABLE_BEYOND_STANDARD_ERROR` is also what `Core::Executor` may settle onto a result (via
+`Extensions.swallowable?`) — the single answer to "what will axn ever swallow." It's an allowlist,
+widened only for a class that's unambiguously a fault in the code being run: the non-`StandardError`
+set is open-ended (any gem can define a direct `Exception` subclass), and members like
+`Timeout::ExitException` and `ActiveSupport::ErrorReporter::UnexpectedError` exist precisely so
+nothing swallows them. Absorbing one silently breaks whatever it signals, which is far harder to
+trace than an unrecognized bug escaping `.call`.
+
+## Don't dispatch to caller methods while reporting a failure
+
+Separate the caller code a walk **requires** from caller code invoked while **reporting** a
+failure. The first is unavoidable — rendering a value calls its `to_s`/`as_json`, walking a
+container calls its `each` — and a value that lies there changes what we decide, which is the
+caller's own problem. The second is different in kind: an `inspect`, a `class`, an `is_a?`, or a
+`-@` called to build the message can raise and *replace* the failure with the caller's exception,
+and if that exception is outside `StandardError` it escapes the adapter's `rescue` — reinstating
+exactly what the error existed to prevent.
+
+So in a serialization or reflection error path, derive what the message needs without dispatching:
+describe a value by `Object.instance_method(:class).bind_call(it)` rather than `it.class` or
+`it.inspect`, and write type tests as `case`/`when` (`Module#===` is a C-level check) rather than
+`is_a?`, which a value can override to route around a guard.
+
+Eight layers hold this property: `Internal::Reflection::Values`, `Internal::Reflection::PropertyNames`,
+`Internal::ShapeGraph`, `Internal::NativeMethods`, `Internal::Text`, `Internal::Rendering`,
+`Axn::Extensions`, and the contract's declaration walk — including the option-container copy
+`Internal::ShapeGraph` owns, where `Kernel#dup` and `Hash#each` are BOUND rather than dispatched, so
+simplifying `Hash#each` back to a plain `.each` reopens an aliased contract (a bag is copied
+entry-wise whatever its class); the bound `dup` is belt-and-braces, since an Array owning `dup` is
+refused before the copy is attempted.
+
+Dispatch on caller *data* (as opposed to error-path/reporting internals) is a different question,
+and is fine when the dispatch **is** the work:
+
+- The runtime redaction walk type-tests caller data (`is_a?`, `dup`) on every logged call.
+- `Array(klass)` dispatches `to_a` on a caller value.
+- `shape_validator` reports `got #{source.class}`.
+- `subfield_contradictions` lists declared type branches with `#inspect`.
+
+Two more are the projection's own work, both in `Internal::Reflection::Schema` (deliberately not
+one of the eight layers above): `properties[config.field] =` IS the merge rule (one Hash key means
+"two routes, one property, legal"), and `required << config.field.to_s` renders the name JSON will
+carry — so a declared name whose `eql?` or `to_s` raises has no property map, and the emitter says
+so, exactly as a value whose `to_s` raises cannot be rendered. `Internal::Reflection::Values.canonical_wire_key`
+reads a String's or Symbol's rendering without dispatching for the same reason the rules do — it is
+their input, so a dispatch there is a dispatch inside a verdict — and dispatches `to_s` only for a
+name that is neither, where rendering it is the only way to know what property it names.
+
+## Don't build a guard that depends on foreign behaviour being honest
+
+Verifying that a caller's object BEHAVES is unbounded — the body is arbitrary code, so every round
+of verification is defeated by the next case. Two on one PR:
+
+- An option container was copied and the copy compared, first by elements (defeated by a
+  duplication hook that dropped a derived membership index) and then by asking the copy `include?`
+  about each element (defeated by a hook that dropped only the index of accepted non-elements, since
+  membership is not enumerable from outside).
+- A contract failure was renamed and re-raised on the argument that having been raised once made a
+  redispatch safe (defeated by an `#exception` answering itself the first time and raising the
+  second, because renaming CLONES and `raise` then asks the clone).
+
+Ask ownership instead — `Internal::NativeMethods`, reading owners out of the method table rather
+than running the object — and take a simple honest fallback when the object is not native: refuse
+the container (`freeze` it is the documented escape), report axn's own error with the original as
+`cause`. A bounded rule that over-rejects slightly beats an unbounded verification.
+
+But a bounded rule can still be scoped WRONG, and the container half was, twice over: owning the
+duplication hooks is not what makes a copy faithful (the copy's answers must be determined by the
+state `dup` copies faithfully — the elements — which holds only where the answers are Ruby's own),
+and the lookup has to go where the answer will be read. So `own_array_methods` asks for everything
+the container answers with, through its SINGLETON CLASS's ancestry (one walk over singleton
+methods, extended modules and the class's own), because a consumer asks the ORIGINAL and a copy
+carries no singleton. The exception half keeps a named set and an object lookup for a different
+question — what raising will DISPATCH: `clone` copies the singleton class and `raise` asks the
+object it is handed, while `dup` looks its hooks up on the copy's class.
+
+## Rendering declared names and composed messages
+
+Every layer that writes a declared NAME into prose routes it through
+`PropertyNames.inspect_field_name`/`renderable_label` — the contract's declaration errors,
+`shape_validator`, `subfield_contradictions`, `call_logger` — so no message renders a name by
+running the name's own code.
+
+Not running the offender's code is only half of what prose needs, because the bytes it hands back
+are foreign too: a message axn builds is UTF-8, so joining a String that has no UTF-8-compatible
+rendering to one raises `Encoding::CompatibilityError` from the reporting itself — which is why
+those layers RENDER what they write (`renderable_label`: an ASCII string is byte-identical, another
+encoding reads as its text, unrenderable bytes come back escaped), and why a CLASS written into a
+message goes through the one seam that composes both halves
+(`PropertyNames.renderable_class_name`/`renderable_module_name` over `Internal::ClassName`) — a
+constant may hold non-UTF-8 bytes, so naming a class destroyed the report from inside the "a name of
+class …" fallback the name rules escape TO, and from `Axn::Tools.validate_contracts!` naming a tool.
+
+A guarded dispatch and a rendered result are two obligations, and every site that met one of them by
+hand met only that one. The byte primitive lives at the BOTTOM of the gem (`Internal::Text`, zero
+requires) for exactly this reason: `Internal::Reflection::Values`' colliding-key report and both
+`UnserializableValue#message` and `Axn::Async::UnserializableArgument#message` sit in the files the
+renderer is itself built on, so a primitive any higher is out of their reach, and one at the bottom
+is what lets them compose both halves like every other layer — as `Axn::Extensions.best_effort`
+does, from a file that requires none of the reflection stack.
+
+That property is not a property of the guard AROUND one step: `PropertyNames.attributions` rescues
+the provenance WALK, so everything the failure path then does with the walk's result — the path
+lookup, the wording choice, each name written into the message — has to dispatch nothing itself,
+which is why `same_declared_name?` (identity, or a bound `String#==`) replaced `Array#==` in the
+lookup and `==` in the contract's wording choice, and why the collision walk canonicalizes each
+emitted name ONCE and reuses it wherever the path is written. Nor is a guard that only counts
+exempt: the size budget keys a wire key by `wire_key_segment` (a plain copy) and a member name by
+`property_segment` (a bound intern), never by handing the name to a Hash and letting its own
+`hash`/`eql?` answer axn's question.
+
+Where a dispatch to reach the unrenderable check is unavoidable, ask ONCE: canonicalizing a name to
+reach the check and canonicalizing again inside it let a second, different answer overturn a
+verdict already reached, and the schema then advertised a property the contract does not have — the
+same bytes being REJECTED under a name that renders them honestly, since `JSON.generate` asks a
+key's own `to_s` as well and emits whatever the name last claimed. A guard defeated by exactly the
+object it exists to catch is the shape to watch for.
+
+The specific regression: a subclass holding `"other"` and rendering `"dup"` passed the collision
+rules beside a `:dup` field and then emitted `"dup"` twice, and a plain String carrying a singleton
+`to_s` needed no second declaration at all, since the emitter's `required` list named a property its
+`properties` map does not define — because `JSON.generate` renders a Hash key through its `to_s`, so
+a name whose rendering disagrees with its bytes is judged as one property and emitted as another. So
+a declared name that renders through code of its own is REFUSED (`NativeMethods.native_name_rendering?`
+— a Symbol can carry no override, a String must not own `to_s`), which is what makes judging the
+bytes sound rather than arbitrary, and every artifact reads the one name one way
+(`Schema.required_key`). Where three readers pick between two candidate renderings, no choice of
+candidate is a fix; only removing the second candidate is.
+
+Caller data is a different category from an error path: there the dispatch IS the work (rendering a
+value requires its `to_s`), and a value that lies degrades a log line or masks more than necessary.
+But being inside a guard is not what makes that safe, and `best_effort` is the counterexample: it
+built its warning from the exception it had just caught — that exception's class name, its message,
+its backtrace — so an exception whose `#message` raises, or an ordinary one whose STORED message
+holds bytes with no UTF-8 rendering, escaped through the very code meant to contain it, was absorbed
+one layer out, and replaced the settled outcome, leaving `result.exception` naming the reporting
+failure instead of the caller's `InboundValidationError`. A guard has to hold the property in the
+code that REPORTS, not only in the code it wraps, which is why every fact the warning names is read
+through `Internal::Rendering` and the emit itself is backstopped.
+
+### Render at the join, not operand by operand
+
+Half-rendering is strictly worse than rendering nothing: an `Encoding::CompatibilityError` needs
+INCOMPATIBLE operands, and two ISO-8859-1 Strings concatenate fine — so transcoding one of them and
+leaving its neighbour raw converts a composition that worked into a raise. That is not hypothetical;
+it broke three separate paths this way:
+
+- A Latin-1 `fail!` reason beside a Latin-1 `join:` separator (`result.error` raised).
+- A Latin-1 field name beside a Latin-1 `default:` failure (`Encoding::CompatibilityError` in place
+  of `DefaultAssignmentError` — a reporting failure replacing the real error, the exact defect the
+  funnel exists to prevent).
+- A Latin-1 declared name beside a `Date` whose registered `:inspect` format returned Latin-1.
+
+The reason it kept recurring is that per-operand rendering requires ENUMERATING the operands, and
+each enumeration missed a branch the next one found — the third case was a regression introduced by
+the fix for the second. Normalization belongs at the one point every operand flows through, the way
+`MessageResolver#body_for` owns it for handler returns: per-branch rendering is sound only where the
+dispatch is an exhaustive type test whose every branch ends in the funnel, which is what a funnel
+IS. A fix whose correctness depends on six call sites each remembering to render is not a fix; it is
+six chances to be wrong, and the audit that found that one had already been wrong twice.
+
+## Hostile-object-only findings: audit, don't chase
+
+A finding reachable only by an object built to defeat the guard does not earn an exhaustive fix —
+that pursuit is unbounded, since a worse object can always be invented — but it does earn an AUDIT
+of the area, because such a report is evidence the area was written without the hazard in mind.
+
+Three reasons that have held up to justify acting on one:
+
+- It removes a duplicate policy for one question (a method owner was resolved in three places with
+  three different absence policies, and closing that also closed a second caller the report never
+  mentioned).
+- It is the last unguarded instance in a module whose whole purpose is the guard (once `first_frame`
+  read the backtrace container through a bound `Array#first`, every remaining dispatch in
+  `Internal::Rendering` was deliberate, guarded and documented, so the file's stated promise became
+  true rather than nearly true).
+- It fails safe at the same cost as the dispatch it replaces.
+
+What does NOT justify one is that the scenario is imaginable. The audit is the deliverable even when
+the patch is declined — say what you examined and what you left, because "I found nothing else of
+this shape" is the useful answer and is only worth anything if you looked.
+
+## Cycle guards
+
+Any code that recurses through caller-supplied Hash/Array values must cycle-guard with
+`Axn::Internal::CycleGuard.guard` (a self-referential value is a `SystemStackError`, which is
+outside `StandardError` and so escapes the whole result path).
+
+A walk that descends a caller value **in lockstep with a shape graph** guards on the PAIR instead
+(`CycleGuard.guard_pair`), because neither half alone is the walk's position: the same value
+legitimately reappears under a different shape node with members still to validate, so keying on
+the value stops a walk that is not looping and drops real verdicts, while keying on the shape stops
+descending a value that still has members. Pairs only repeat while the graph does, so such a walk
+needs `ShapeGraph::MAX_NESTING` as well — a graph that mints a fresh nested shape per read is
+endless rather than cyclic and repeats nothing at all.
+
+For third-party code that recurses and can't be guarded from inside — `ActiveSupport::ParameterFilter`
+— rescue `SystemStackError` and retry on `CycleGuard.decycle(data)`, so acyclic data pays for
+neither the extra walk nor the copy.

--- a/internal-docs/agent-notes/guards-and-projections.md
+++ b/internal-docs/agent-notes/guards-and-projections.md
@@ -1,0 +1,62 @@
+# Guards and projections: case studies and mechanism
+
+This file holds mechanism and case studies only. The rule each section backs is stated in
+`AGENTS.md`; if you find yourself wanting to add a new rule here instead of there, put it in
+`AGENTS.md` and link back.
+
+## A guard derives from what its consumer emits; it never predicts it
+
+When a check must agree with a projection — the property-name rules against
+`Internal::Reflection::Schema`'s emitted properties, say — read the consumer's own output or call
+the consumer's own decision (`Schema.shape_property_plan`, `Schema.build_input_for`), rather than
+re-deriving the answer beside it.
+
+A predictor is wrong in two directions at once and both are worse than a late diagnosis: it misses
+what the consumer emits by a path the predictor doesn't know, and it *rejects legal declarations*
+the consumer would never emit at all. SEVEN defects on one PR shared that root, and each
+seam-by-seam fix generated the next one until every charge and claim was routed through the
+emitter's own decision.
+
+The last two were in a size BUDGET rather than a name check, which is the form to watch for: a
+per-declaration charge predicts "this will emit a property", so it rejected a contract whose schema
+names nothing — a config rooted at `on: :ambient_context`, a subfield under a parent that cannot
+hold object properties, a `model:` route's own type on input. A budget spends on what the emitter
+emits (`SubfieldTree`'s index and `path_blocked?`, `Schema.shape_property_plan`) or it is a
+predictor with a number attached.
+
+When a charge cannot be exact, know which way it errs and say so: UNDER-counting only loosens a
+bound, while OVER-counting rejects a legal declaration. This is also why a check may legitimately
+fire later than declaration: if only the emitted schema reveals a collision, the honest promise is
+"before anything can consume it" (at app setup for tools, via `Axn::Tools.validate_contracts!`), not
+"at declaration".
+
+## Canonicalization obliges a re-audit of every guard on the raw form
+
+Symbolizing keys, defaulting an absent list to `[]`, normalizing a name — each silently disarms any
+downstream check that distinguished what you just erased. Three regressions on one PR:
+
+- `[]`-for-absent hid `ShapeValidator`'s "must supply :members".
+- String-keyed option bags hid `_reject_model_transform!`.
+- String-keyed option bags made `FieldOptionality#optional?` answer `false` for a declared
+  `allow_blank`, publishing a wrong `required` list that adapters build tool definitions from.
+
+Enumerate the consumers of both forms in the same commit, and say which still fire.
+
+## Returning the caller's object unchanged is an aliasing bug
+
+A fast path skipping work because "nothing needs changing" answers a different question than
+"nothing needs copying" — a declared contract must be axn's own, so mutating what the caller still
+holds cannot change it retroactively.
+
+One exception, and it is the same question answered rather than dodged: an option container that is
+already FROZEN is stored as the caller's object (`Internal::ShapeGraph.detached_option_array`),
+because "nothing can change it afterwards" is precisely the property the copy was buying — to the
+same one-level depth, since a frozen container's elements are still the caller's objects, exactly as
+a copy's are.
+
+And a copy detaches only what it actually copies: `Kernel#dup` copies an Array's ELEMENTS while
+sharing the instance variables and dropping the singleton class, so a container whose own code
+answers from either is not detached by being copied, it is silently changed. (This is the same
+`dup`/singleton-class mechanic detailed in `error-paths.md`'s "don't build a guard that depends on
+foreign behaviour being honest" — the container copy there and this aliasing rule are two sides of
+the same fact about `dup`.)

--- a/internal-docs/agent-notes/namespaces.md
+++ b/internal-docs/agent-notes/namespaces.md
@@ -1,0 +1,28 @@
+# Namespaces: case studies and mechanism
+
+This file holds mechanism and case studies only. The rule each section backs is stated in
+`AGENTS.md`; if you find yourself wanting to add a new rule here instead of there, put it in
+`AGENTS.md` and link back.
+
+## `Internal::Reflection::X` membership footholds
+
+Building and validating a schema, and rendering a result, mostly run off the execution path, but
+that's not a blanket guarantee of membership: `Schema` and `PropertyNames` each keep a narrow
+foothold ON it (a memoized model-field default check; a small set of runtime callers naming a field
+only when reporting a failure), while `Values` has none. See `Internal::Reflection`'s own header for
+exactly which callers and when.
+
+## Why `Axn::Error` is a module, not a base class
+
+Tagging a class with `include Axn::Error` costs it no ancestry, which is what lets an adapter gem
+keep a base its own ecosystem requires — `Faraday::Error`, `Timeout::Error` — while still being
+catchable as an axn error. A sibling gem roots its own hierarchy there:
+`class Axn::Webhooks::Error < StandardError; include Axn::Error; end`.
+
+`Axn::Failure` is excluded because it's a control-flow signal from `call!`, not a fault: tagging it
+would make `rescue Axn::Error` catch the intended outcome while still missing an unintended
+`NoMethodError` from the action body.
+
+No public exception class inherits out of `Axn::Internal`. Where six once did, the internal base
+was an ancestor and nothing else, and `rescue Axn::Error` is how "any registry lookup miss" is
+expressed now.


### PR DESCRIPTION
## Summary

`AGENTS.md` is read into every session and had grown to 35,425 chars — roughly half of it post-mortem case-study prose backing rules rather than the rules themselves (`## Errors` alone was 46% of the file). This splits each long paragraph into a short imperative rule (kept in `AGENTS.md`) plus a pointer phrased as a condition on the work, moving the mechanism and case studies to new files under `internal-docs/agent-notes/`.

- `AGENTS.md`: 35,425 → 18,485 chars (~49% reduction). No rule's substance changed — only placement.
- New: `internal-docs/agent-notes/{error-paths,guards-and-projections,namespaces,ab-testing-guards}.md`, each opening with the "mechanism and case studies only, rules live in AGENTS.md" invariant so future edits don't drift.
- `AGENTS.md` now names `AGENTS-consuming.md` and `AGENTS-tool-adapters.md`, which it previously never referenced.

Linear: https://linear.app/teamshares/issue/PRO-3057

## Test plan

- [ ] Skim `AGENTS.md` end-to-end and confirm nothing that should still constrain future code got lost in the split (spot-check a couple of the moved paragraphs against their satellite file).