### PR TITLE
PRO-2940: remove the dead skip guards in the tool registry spec

### DIFF
--- a/spec/axn/tools/registry_spec.rb
+++ b/spec/axn/tools/registry_spec.rb
@@ -354,10 +354,7 @@ RSpec.describe Axn::Tools::Registry do
       register_adapter_with_roots(:mcp, roots: [fixture_dir])
     end
 
-    # Both failing siblings are isolated by the SAME single load, and `require` runs a file at most once
-    # per process — so the StandardError case and the LoadError case have to be asserted together here
-    # rather than as two examples (the second would find the fixture already loaded and have nothing to do).
-    it "loads the good tool despite siblings raising StandardError and LoadError, warning about both" do
+    it "loads the good tool despite a sibling file raising at load time, warning about the bad one" do
       warnings = []
       allow(Axn.config.logger).to receive(:warn) { |*args, &block| warnings << (block ? block.call : args.first) }
 
@@ -366,6 +363,16 @@ RSpec.describe Axn::Tools::Registry do
       expect(Object.const_defined?("RegistryFixturesMixed::GoodMixedTool")).to be(true)
       expect(tools).to include(RegistryFixturesMixed::GoodMixedTool)
       expect(warnings).to include(a_string_matching(/bad_mixed_tool\.rb.*boom/))
+    end
+
+    it "loads the good tool despite a sibling file raising LoadError at load time, warning about it too" do
+      warnings = []
+      allow(Axn.config.logger).to receive(:warn) { |*args, &block| warnings << (block ? block.call : args.first) }
+
+      tools = Axn::Tools.for(:mcp)
+
+      expect(Object.const_defined?("RegistryFixturesMixed::GoodMixedTool")).to be(true)
+      expect(tools).to include(RegistryFixturesMixed::GoodMixedTool)
       expect(warnings).to include(a_string_matching(/load_error_mixed_tool\.rb.*LoadError/))
     end
   end

--- a/spec/axn/tools/registry_spec.rb
+++ b/spec/axn/tools/registry_spec.rb
@@ -340,8 +340,6 @@ RSpec.describe Axn::Tools::Registry do
     end
 
     it "requires .rb files under a configured tool dir and exposes them as tools" do
-      skip "fixture already loaded" if Object.const_defined?("RegistryFixtures::LazyRegistryTool")
-
       tools = Axn::Tools.for(:mcp)
       expect(Object.const_defined?("RegistryFixtures::LazyRegistryTool")).to be(true)
       expect(tools).to include(RegistryFixtures::LazyRegistryTool)
@@ -356,9 +354,10 @@ RSpec.describe Axn::Tools::Registry do
       register_adapter_with_roots(:mcp, roots: [fixture_dir])
     end
 
-    it "loads the good tool despite a sibling file raising at load time, warning about the bad one" do
-      skip "fixture already loaded" if Object.const_defined?("RegistryFixturesMixed::GoodMixedTool")
-
+    # Both failing siblings are isolated by the SAME single load, and `require` runs a file at most once
+    # per process — so the StandardError case and the LoadError case have to be asserted together here
+    # rather than as two examples (the second would find the fixture already loaded and have nothing to do).
+    it "loads the good tool despite siblings raising StandardError and LoadError, warning about both" do
       warnings = []
       allow(Axn.config.logger).to receive(:warn) { |*args, &block| warnings << (block ? block.call : args.first) }
 
@@ -367,18 +366,6 @@ RSpec.describe Axn::Tools::Registry do
       expect(Object.const_defined?("RegistryFixturesMixed::GoodMixedTool")).to be(true)
       expect(tools).to include(RegistryFixturesMixed::GoodMixedTool)
       expect(warnings).to include(a_string_matching(/bad_mixed_tool\.rb.*boom/))
-    end
-
-    it "loads the good tool despite a sibling file raising LoadError at load time, warning about it too" do
-      skip "fixture already loaded" if Object.const_defined?("RegistryFixturesMixed::GoodMixedTool")
-
-      warnings = []
-      allow(Axn.config.logger).to receive(:warn) { |*args, &block| warnings << (block ? block.call : args.first) }
-
-      tools = Axn::Tools.for(:mcp)
-
-      expect(Object.const_defined?("RegistryFixturesMixed::GoodMixedTool")).to be(true)
-      expect(tools).to include(RegistryFixturesMixed::GoodMixedTool)
       expect(warnings).to include(a_string_matching(/load_error_mixed_tool\.rb.*LoadError/))
     end
   end
@@ -451,8 +438,6 @@ RSpec.describe Axn::Tools::Registry do
     it "loads a valid sibling despite a SyntaxError file, warning about the bad one and not raising" do
       require "tmpdir"
 
-      skip "fixture already loaded" if Object.const_defined?("SyntaxIsoFixture::Ok")
-
       dir = Dir.mktmpdir("axn_syntax_iso")
       begin
         File.write(File.join(dir, "ok_tool.rb"), <<~RUBY)
@@ -492,8 +477,6 @@ RSpec.describe Axn::Tools::Registry do
     end
 
     it "exposes the good tool but rolls back the class registered by the failing file" do
-      skip "fixture already loaded" if Object.const_defined?("GoodFailedFixture::Ok")
-
       warnings = []
       allow(Axn.config.logger).to receive(:warn) { |*args, &block| warnings << (block ? block.call : args.first) }
 
@@ -519,8 +502,6 @@ RSpec.describe Axn::Tools::Registry do
     end
 
     it "keeps a valid tool required by the failing file, rolling back only the failing file's own class" do
-      skip "fixture already loaded" if Object.const_defined?("NestedDep::Good")
-
       warnings = []
       allow(Axn.config.logger).to receive(:warn) { |*args, &block| warnings << (block ? block.call : args.first) }
 


### PR DESCRIPTION
Closes the `there's still at least one pending spec - why?` row on [PRO-2940](https://linear.app/teamshares/issue/PRO-2940/axn-alpha-6).

## Why there was a pending spec

`spec/axn/tools/registry_spec.rb` carried five `skip "fixture already loaded"` guards. One of them fired on every run, so the suite reported `1 pending` — the LoadError half of the mixed-fixture isolation test never executed.

That wasn't a flaky or environment-gated skip. It was dead coverage on a real guarantee: that `ensure_loaded!` rescues `ScriptError`/`LoadError`, not just `StandardError`.

## What changed

Removed all five guards. Nothing else — the net diff is the deletion of five `skip` lines.

They could never usefully fire. Nothing outside this file references those fixture dirs or constants, so the only thing that could define the constant is the spec run itself; and where the constant *is* already defined, the example still passes on its own merits (see below). A skip that can't fire is dead code, and keeping the pattern means a future second example in one of those blocks silently goes pending rather than failing.

## Verification

- `bundle exec rspec` → `5151 examples, 0 failures`, no Pending section (was `5151 examples, 0 failures, 1 pending`).
- `spec_rails` → `361 examples, 0 failures`.
- Rubocop clean.
- The previously-skipped LoadError example passes **run alone** (`1 example, 0 failures`) and under random seeds, so it no longer depends on its sibling having run first.
- Inverse mutation, to confirm the newly-live assertion is load-bearing rather than vacuous: narrowing the per-file rescue at `lib/axn/tools/registry.rb:159` from `rescue StandardError, ScriptError` to `rescue StandardError` makes that example fail, with the LoadError escaping `ensure_loaded!`. Reverted after.

## Note on the failed-require semantics

An earlier revision of this PR consolidated the two mixed-fixture examples, on the premise that `require` is once-per-process so the second could never re-exercise the path. That premise was wrong, and Codex caught it. Ruby drops a file from `$LOADED_FEATURES` when its body raises, so a *failing* require is never cached:

```
require raiser.rb  attempt 1: [BODY EXECUTED] raised RuntimeError  in $LOADED_FEATURES? false
require raiser.rb  attempt 2: [BODY EXECUTED] raised RuntimeError  in $LOADED_FEATURES? false
require good.rb    attempt 1: [BODY EXECUTED] returned true        in $LOADED_FEATURES? true
require good.rb    attempt 2:                 returned false       in $LOADED_FEATURES? true
```

Only `good_mixed_tool.rb` is once-per-process, and the `include` assertion on it holds either way. Both examples stand on their own, so the consolidation bought nothing and has been reverted.

## Found but deliberately not fixed here

The suite is order-dependent — `bundle exec rspec --order random:1` fails 6 examples. **Pre-existing**: confirmed by running seeds 1/42/1234/777 against `a7d70fe2` in a detached worktree and getting identical failure counts before and after this change.

Filed as [PRO-3066](https://linear.app/teamshares/issue/PRO-3066/axn-spec-suite-is-order-dependent-6-examples-fail-under-random-order). Kept out of scope because it isn't cleanup: the tool fixtures leak into `Axn::Tools::Registry._classes` permanently, and `spec_helper.rb` already declines to reset that on purpose (it's the record of `include Axn`, a once-per-process side effect). The fix is reworking the `.members` assertions that `contain_exactly` against the process-global registry — a behavioral change with its own review surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)