### PR TITLE
PRO-3066: fix order-dependent spec failures under random ordering

### DIFF
--- a/spec/axn/core/global_on_exception_spec.rb
+++ b/spec/axn/core/global_on_exception_spec.rb
@@ -1,15 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe "Global on_exception handler" do
-  let(:original_handler) { Axn.config.instance_variable_get(:@on_exception) }
   before do
+    # Capture the real prior handler BEFORE clearing it — a `let` here would memoize lazily on
+    # first reference, which (without this eager read) wouldn't happen until `after` reads it, by
+    # which point the example has already replaced it. That silently "restores" a handler an
+    # example itself just installed (e.g. a deliberately-raising one), leaking it into every
+    # example that runs afterward in the process.
+    @original_on_exception_handler = Axn.config.instance_variable_get(:@on_exception)
     # Clear any existing global handler
     Axn.config.instance_variable_set(:@on_exception, nil)
   end
 
   after do
     # Restore original handler
-    Axn.config.instance_variable_set(:@on_exception, original_handler)
+    Axn.config.instance_variable_set(:@on_exception, @original_on_exception_handler)
   end
 
   describe "basic functionality" do

--- a/spec/axn/core/method_call_spec.rb
+++ b/spec/axn/core/method_call_spec.rb
@@ -353,9 +353,13 @@ RSpec.describe "expects ..., method_call: true" do
   end
 
   describe "loud failure when the flag is omitted" do
-    let(:original_handler) { Axn.config.instance_variable_get(:@on_exception) }
+    # Capture the real prior handler BEFORE clearing it — a `let` here would memoize lazily on
+    # first reference, which wouldn't happen until `after` reads it, by which point some examples
+    # below have already replaced it. That "restores" a handler an example itself just installed,
+    # leaking it into every example that runs afterward in the process.
+    before { @original_on_exception_handler = Axn.config.instance_variable_get(:@on_exception) }
     before { Axn.config.instance_variable_set(:@on_exception, nil) }
-    after { Axn.config.instance_variable_set(:@on_exception, original_handler) }
+    after { Axn.config.instance_variable_set(:@on_exception, @original_on_exception_handler) }
 
     let(:action) do
       build_axn do

--- a/spec/axn/core/nested_exception_reporting_spec.rb
+++ b/spec/axn/core/nested_exception_reporting_spec.rb
@@ -4,14 +4,18 @@
 # (e.g. Honeybadger) must fire ONCE per exception, not once per executor it passes through.
 RSpec.describe "Nested exception reporting (report once)" do
   let(:reports) { [] }
-  let(:original) { Axn.config.instance_variable_get(:@on_exception) }
 
   before do
+    # Capture the real prior handler BEFORE overwriting it — a `let` here would memoize lazily on
+    # first reference, which wouldn't happen until `after` reads it, by which point the example has
+    # already replaced it. That "restores" a handler this very hook (or the example) just
+    # installed, leaking it into every example that runs afterward in the process.
+    @original_on_exception_handler = Axn.config.instance_variable_get(:@on_exception)
     sink = reports
     Axn.config.instance_variable_set(:@on_exception, ->(exception, action:, **) { sink << [exception, action.class] })
   end
 
-  after { Axn.config.instance_variable_set(:@on_exception, original) }
+  after { Axn.config.instance_variable_set(:@on_exception, @original_on_exception_handler) }
 
   it "reports a top-level unhandled exception once (baseline)" do
     stub_const("TopBug", build_axn { def call = raise("top boom") })

--- a/spec/axn/core/testing/result_for_specs_spec.rb
+++ b/spec/axn/core/testing/result_for_specs_spec.rb
@@ -167,14 +167,18 @@ RSpec.describe "Action spec helpers" do
 
   describe "Axn::Result.ok and Axn::Result.error skip logging and error handlers" do
     let(:log_messages) { [] }
-    let(:original_handler) { Axn.config.instance_variable_get(:@on_exception) }
 
     before do
+      # Capture the real prior handler BEFORE clearing it — a `let` here would memoize lazily on
+      # first reference, which wouldn't happen until `after` reads it, by which point it may have
+      # already been replaced. That "restores" whatever is current at that point rather than the
+      # true original, leaking it into every example that runs afterward in the process.
+      @original_on_exception_handler = Axn.config.instance_variable_get(:@on_exception)
       Axn.config.instance_variable_set(:@on_exception, nil)
     end
 
     after do
-      Axn.config.instance_variable_set(:@on_exception, original_handler)
+      Axn.config.instance_variable_set(:@on_exception, @original_on_exception_handler)
     end
 
     describe "Axn::Result.ok" do

--- a/spec/axn/extras/strategies/client_spec.rb
+++ b/spec/axn/extras/strategies/client_spec.rb
@@ -169,13 +169,16 @@ RSpec.describe Axn::Extras::Strategies::Client do
       it "does not inject ErrorHandlerMiddleware when error_handler is nil" do
         instance = create_client_instance(test_action, error_handler: nil)
 
-        expect(middleware_klasses(instance.client)).not_to include(Axn::Extras::Strategies::Client::ErrorHandlerMiddleware)
+        # ErrorHandlerMiddleware is defined lazily (only once some example actually uses
+        # error_handler:), so referencing the constant directly here would raise NameError if this
+        # example runs before that one. Compare by name instead of by class.
+        expect(middleware_klasses(instance.client).map(&:name)).not_to include("Axn::Extras::Strategies::Client::ErrorHandlerMiddleware")
       end
 
       it "does not inject ErrorHandlerMiddleware when error_handler is not provided" do
         instance = create_client_instance(test_action)
 
-        expect(middleware_klasses(instance.client)).not_to include(Axn::Extras::Strategies::Client::ErrorHandlerMiddleware)
+        expect(middleware_klasses(instance.client).map(&:name)).not_to include("Axn::Extras::Strategies::Client::ErrorHandlerMiddleware")
       end
     end
 

--- a/spec/axn/mountable/steps/failure_semantics_spec.rb
+++ b/spec/axn/mountable/steps/failure_semantics_spec.rb
@@ -5,15 +5,19 @@
 # parent as a FAILURE (on_failure); a step that raises an unclassified exception settles the parent
 # as an EXCEPTION (on_exception, never on_failure), with exactly one global report at the step.
 RSpec.describe "Step failure vs exception semantics" do
-  let(:original_handler) { Axn.config.instance_variable_get(:@on_exception) }
   let(:reports) { [] }
 
   before do
+    # Capture the real prior handler BEFORE overwriting it — a `let` here would memoize lazily on
+    # first reference, which wouldn't happen until `after` reads it, by which point this hook has
+    # already replaced it. That "restores" the handler this very hook just installed, leaking it
+    # into every example that runs afterward in the process.
+    @original_on_exception_handler = Axn.config.instance_variable_get(:@on_exception)
     captured = reports
     Axn.config.instance_variable_set(:@on_exception, ->(e, **) { captured << e })
   end
 
-  after { Axn.config.instance_variable_set(:@on_exception, original_handler) }
+  after { Axn.config.instance_variable_set(:@on_exception, @original_on_exception_handler) }
 
   describe "step calls fail! (deliberate failure)" do
     it "settles the parent as a failure, fires on_failure (not on_exception), and does not report" do

--- a/spec/axn/strategies_spec.rb
+++ b/spec/axn/strategies_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe Axn::Strategies do
       end
     end
 
+    # Registers `:custom` without deregistering it, which would leak into whichever example runs
+    # next under random ordering (mirrors the same cleanup in the "a registry" shared examples).
+    after { described_class.instance_variable_get(:@items)&.delete(:custom) }
+
     it "allows custom strategies to be used" do
       described_class.clear!
       described_class.register(:custom, custom_strategy)

--- a/spec/axn/tools/registry_spec.rb
+++ b/spec/axn/tools/registry_spec.rb
@@ -339,6 +339,13 @@ RSpec.describe Axn::Tools::Registry do
       register_adapter_with_roots(:mcp, roots: [fixture_dir])
     end
 
+    # The fixture is loaded via a real `require` (not `stub_const`), so its constant outlives this
+    # example unless dropped here — otherwise it permanently pollutes every later example's view of
+    # `Axn::Tools.for(:mcp)` (order-dependent under random ordering).
+    after do
+      Object.send(:remove_const, :RegistryFixtures) if Object.const_defined?(:RegistryFixtures, false)
+    end
+
     it "requires .rb files under a configured tool dir and exposes them as tools" do
       tools = Axn::Tools.for(:mcp)
       expect(Object.const_defined?("RegistryFixtures::LazyRegistryTool")).to be(true)
@@ -352,6 +359,15 @@ RSpec.describe Axn::Tools::Registry do
 
     before do
       register_adapter_with_roots(:mcp, roots: [fixture_dir])
+    end
+
+    # Both examples below `require` the same real fixture file, and `require` is idempotent per
+    # process — a per-example (`after(:each)`) removal would delete the constant before the second
+    # example runs, and the file would never re-execute to redefine it. Clean up once, after both
+    # examples in this group have run, so the constant doesn't outlive the group and pollute later
+    # examples elsewhere in the file (order-dependent under random ordering).
+    after(:context) do
+      Object.send(:remove_const, :RegistryFixturesMixed) if Object.const_defined?(:RegistryFixturesMixed, false)
     end
 
     it "loads the good tool despite a sibling file raising at load time, warning about the bad one" do
@@ -472,6 +488,9 @@ RSpec.describe Axn::Tools::Registry do
         expect(warnings).to include(a_string_matching(/broken_tool\.rb.*SyntaxError/))
       ensure
         FileUtils.remove_entry(dir)
+        # The tmpdir is gone, but the file was `require`d for real, so its constant would otherwise
+        # outlive this example and pollute later examples' view of `Axn::Tools.for(:mcp)`.
+        Object.send(:remove_const, :SyntaxIsoFixture) if Object.const_defined?(:SyntaxIsoFixture, false)
       end
     end
   end
@@ -481,6 +500,12 @@ RSpec.describe Axn::Tools::Registry do
 
     before do
       register_adapter_with_roots(:mcp, roots: [fixture_dir])
+    end
+
+    # `GoodFailedFixture::Ok` is `require`d for real, so it outlives this example unless dropped
+    # here, polluting later examples' view of `Axn::Tools.for(:mcp)` under random ordering.
+    after do
+      Object.send(:remove_const, :GoodFailedFixture) if Object.const_defined?(:GoodFailedFixture, false)
     end
 
     it "exposes the good tool but rolls back the class registered by the failing file" do
@@ -506,6 +531,12 @@ RSpec.describe Axn::Tools::Registry do
 
     before do
       register_adapter_with_roots(:mcp, roots: [fixture_dir])
+    end
+
+    # `NestedDep::Good` is `require`d for real, so it outlives this example unless dropped here,
+    # polluting later examples' view of `Axn::Tools.for(:mcp)` under random ordering.
+    after do
+      Object.send(:remove_const, :NestedDep) if Object.const_defined?(:NestedDep, false)
     end
 
     it "keeps a valid tool required by the failing file, rolling back only the failing file's own class" do

--- a/spec/support/shared_examples/registry_behavior.rb
+++ b/spec/support/shared_examples/registry_behavior.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "a registry" do
+  # Several examples below register a `:custom` item without deregistering it, which would leak
+  # into whichever example runs next under random ordering (`.clear!` only restores built-ins, so
+  # a leaked `:custom` collides with any later `register(:custom, ...)` call, including the
+  # `.clear!` example's own). Drop the leaked key directly rather than via `.clear!`/`.built_in` —
+  # some examples set message expectations on those methods, and an extra call here would double-count.
+  after { described_class.instance_variable_get(:@items)&.delete(:custom) }
+
   describe ".built_in" do
     it "loads all files from the appropriate directory" do
       expect(described_class.built_in.keys).to include(*expected_built_in_keys)
@@ -98,6 +105,10 @@ RSpec.shared_examples "a registry" do
 
   describe ".clear!" do
     it "resets to built-in items only" do
+      # `clear!` first, like every other example above: some OTHER spec file elsewhere in the
+      # suite may have registered `:custom` (or another shared key) and not cleaned up after
+      # itself, and this example must not depend on running before that happens.
+      described_class.clear!
       described_class.register(:custom, Module.new)
       described_class.clear!
       expect(described_class.all.keys).to include(*expected_built_in_keys)


### PR DESCRIPTION
## Summary

Fixes several process-global state leaks in the spec suite that only surface under `--order random`. All changes are spec-only; no production code changed.

- The shared `"a registry"` examples (`spec/support/shared_examples/registry_behavior.rb`) register a `:custom` key without deregistering it, and the `.clear!` example itself registers `:custom` without clearing first — so it collides with a leaked `:custom` left by an earlier example (including `strategies_spec.rb`'s own separate `.register` example).
- `Axn::Extras::Strategies::Client::ErrorHandlerMiddleware` is defined lazily (only once some example actually uses `error_handler:`). Two `client_spec.rb` examples referenced the constant directly to assert its absence, raising `NameError` if they ran before the one example that triggers its definition.
- Several `spec/axn/tools/registry_spec.rb` examples `require` real fixture files (not `stub_const`), permanently registering tool classes in `Axn::Tools::Registry` that other examples' exact-membership assertions (`contain_exactly`/`eq`) don't expect.
- Five specs try to save/restore the global `on_exception` handler via a `let(:original_handler) { ... }` that's never read before the handler is overwritten in `before`. The `let` memoizes lazily, so by the time `after` reads it to "restore" it, it just captures the already-overwritten value — silently leaking a stub handler (in one case a deliberately-raising one) into every example that runs afterward in the process.

Linear: https://linear.app/teamshares/issue/PRO-3066/axn-spec-suite-is-order-dependent-6-examples-fail-under-random-order

Verified locally with ~40 full-suite `--order random` runs (both the originally-failing seeds and fresh random seeds), all green, plus a defined-order run and `rubocop` on all changed files.